### PR TITLE
Implement an initial version of the `#[mir_pattern]` macro

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -850,8 +850,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "rpl_macros"
+version = "0.1.0"
+dependencies = [
+ "quote",
+ "rpl_mir_pattern_expand",
+ "rpl_mir_pattern_syntax",
+ "syn",
+]
+
+[[package]]
 name = "rpl_mir_pattern"
 version = "0.1.0"
+
+[[package]]
+name = "rpl_mir_pattern_expand"
+version = "0.1.0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rpl_mir_pattern_syntax",
+ "syn",
+ "thiserror",
+]
 
 [[package]]
 name = "rpl_mir_pattern_syntax"
@@ -867,6 +888,7 @@ dependencies = [
 name = "rpl_patterns"
 version = "0.1.0"
 dependencies = [
+ "rpl_macros",
  "rpl_mir_pattern",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,9 @@
 members = [
     "crates/rpl_driver",
     "crates/rpl_interface",
+    "crates/rpl_macros",
     "crates/rpl_mir_pattern",
+    "crates/rpl_mir_pattern/expand",
     "crates/rpl_mir_pattern/syntax",
     "crates/rpl_patterns",
     "./"
@@ -20,7 +22,9 @@ repository = "https://github.com/stuuupidcat/RPL"
 [workspace.dependencies]
 rpl_driver = { path = "./crates/rpl_driver" }
 rpl_interface = { path = "./crates/rpl_interface" }
+rpl_macros = { path = "./crates/rpl_macros" }
 rpl_mir_pattern = { path = "./crates/rpl_mir_pattern" }
+rpl_mir_pattern_expand = { path = "./crates/rpl_mir_pattern/expand" }
 rpl_mir_pattern_syntax = { path = "./crates/rpl_mir_pattern/syntax" }
 rpl_patterns = { path = "./crates/rpl_patterns" }
 rustc_tools_util = "0.3.0"
@@ -31,7 +35,7 @@ itertools = "0.12"
 rustc-semver = "1.1"
 walkdir = "2.3"
 quote = "1.0"
-syn = "2.0" 
+syn = { version = "2.0", features = ["full"] }
 proc-macro2 = "1.0"
 tracing = "0.1.28"
 thiserror = "1.0"

--- a/crates/rpl_macros/Cargo.toml
+++ b/crates/rpl_macros/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "rpl_macros"
+version.workspace = true
+description.workspace = true
+repository.workspace = true
+license.workspace = true
+keywords.workspace = true
+edition.workspace = true
+
+[lib]
+proc-macro = true
+
+[dependencies]
+rpl_mir_pattern_syntax.workspace = true
+rpl_mir_pattern_expand.workspace = true
+syn.workspace = true
+quote.workspace = true

--- a/crates/rpl_macros/src/lib.rs
+++ b/crates/rpl_macros/src/lib.rs
@@ -1,0 +1,11 @@
+use proc_macro::TokenStream;
+use quote::ToTokens;
+
+extern crate rpl_mir_pattern_expand as expand;
+extern crate rpl_mir_pattern_syntax as syntax;
+
+#[proc_macro_attribute]
+pub fn mir_pattern(_attribute: TokenStream, input: TokenStream) -> TokenStream {
+    let expanded = syn::parse_macro_input!(input as expand::MirPatternFn).into_token_stream();
+    expanded.into()
+}

--- a/crates/rpl_mir_pattern/expand/Cargo.toml
+++ b/crates/rpl_mir_pattern/expand/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "rpl_patterns"
+name = "rpl_mir_pattern_expand"
 version.workspace = true
 description.workspace = true
 repository.workspace = true
@@ -8,8 +8,11 @@ keywords.workspace = true
 edition.workspace = true
 
 [dependencies]
-rpl_macros.workspace = true
-rpl_mir_pattern.workspace = true
+quote.workspace = true
+syn.workspace = true
+proc-macro2.workspace = true
+thiserror.workspace = true
+rpl_mir_pattern_syntax.workspace = true
 
 [features]
 

--- a/crates/rpl_mir_pattern/expand/src/expand.rs
+++ b/crates/rpl_mir_pattern/expand/src/expand.rs
@@ -1,0 +1,672 @@
+use proc_macro2::TokenStream;
+use quote::{format_ident, quote_each_token, quote_token, ToTokens};
+use rustc_data_structures::sync::Lock;
+use syn::punctuated::{Pair, Pairs, Punctuated};
+use syn::Ident;
+use syntax::*;
+
+use crate::{MirPatternFn, SymbolTable};
+
+pub(crate) struct ExpandCtxt<'ecx> {
+    symbols: Lock<SymbolTable>,
+    tcx: &'ecx Ident,
+    patterns: &'ecx Ident,
+}
+
+#[cfg(test)]
+pub(crate) fn expand_impl<T>(tcx: &Ident, patterns: &Ident, value: T) -> TokenStream
+where
+    for<'ecx> Expand<'ecx, T>: ToTokens,
+{
+    let ecx = ExpandCtxt::new(tcx, patterns);
+    ecx.expand(value).to_token_stream()
+}
+
+pub fn expand(mir_pattern: MirPatternFn) -> TokenStream {
+    std::panic::catch_unwind(|| mir_pattern.into_token_stream())
+        .unwrap_or_else(|err| err.downcast::<syn::Error>().unwrap().into_compile_error())
+}
+
+trait ExpandIdent: Sized + std::borrow::Borrow<Ident> + Into<Ident> {
+    fn with_suffix(&self, suffix: impl std::fmt::Display) -> Ident {
+        let ident = self.borrow();
+        format_ident!("{ident}{suffix}")
+    }
+    // fn with_span(self, span: Span) -> Ident {
+    //     let mut ident = self.into();
+    //     ident.set_span(span);
+    //     ident
+    // }
+    fn as_symbol(&self) -> IdentSymbol<'_> {
+        IdentSymbol(self.borrow())
+    }
+    fn as_ty(&self) -> Ident {
+        self.with_suffix("_ty")
+    }
+    fn as_ty_var(&self) -> Ident {
+        self.with_suffix("_ty_var")
+    }
+    fn as_local(&self) -> Ident {
+        self.with_suffix("_local")
+    }
+    fn as_stmt(&self) -> Ident {
+        self.with_suffix("_stmt")
+    }
+}
+
+impl ExpandIdent for Ident {}
+
+impl<'ecx> ExpandCtxt<'ecx> {
+    pub(crate) fn new(tcx: &'ecx Ident, patterns: &'ecx Ident) -> Self {
+        Self {
+            symbols: Lock::new(SymbolTable::default()),
+            tcx,
+            patterns,
+        }
+    }
+    pub(crate) fn expand<T>(&self, value: T) -> Expand<'_, T> {
+        Expand { value, ecx: self }
+    }
+    fn expand_punctuated<'a, U: 'a, P: 'a>(
+        &'ecx self,
+        value: &'a Punctuated<U, P>,
+    ) -> ExpandPunctPairs<'ecx, 'a, U, P> {
+        self.expand_with(value, Punctuated::pairs)
+    }
+    fn expand_punctuated_mapped<'a, U: 'a, V: 'a, P: 'a>(
+        &'ecx self,
+        value: &'a Punctuated<U, P>,
+        f: fn(&'a U) -> V,
+    ) -> ExpandPunct<'ecx, 'a, U, P, impl Fn(&'a Punctuated<U, P>) -> impl IntoIterator<Item = Pair<V, &'a P>>> {
+        self.expand_with(value, move |value| value.pairs().map_value(f))
+    }
+    fn expand_with<'a, U: 'a, I, F: Fn(&'a U) -> I>(&'ecx self, value: &'a U, f: F) -> ExpandWith<'ecx, &'a U, F> {
+        ExpandWith { value, f, ecx: self }
+    }
+}
+
+type ExpandPunct<'ecx, 'a, U, P, F> = ExpandWith<'ecx, &'a Punctuated<U, P>, F>;
+type ExpandPunctPairs<'ecx, 'a, U, P> = ExpandPunct<'ecx, 'a, U, P, fn(&'a Punctuated<U, P>) -> Pairs<'a, U, P>>;
+
+pub(crate) struct Expand<'ecx, T> {
+    value: T,
+    ecx: &'ecx ExpandCtxt<'ecx>,
+}
+
+struct ExpandWith<'ecx, T, F> {
+    value: T,
+    f: F,
+    ecx: &'ecx ExpandCtxt<'ecx>,
+}
+
+impl<'ecx, T> std::ops::Deref for Expand<'ecx, T> {
+    type Target = ExpandCtxt<'ecx>;
+
+    fn deref(&self) -> &Self::Target {
+        self.ecx
+    }
+}
+
+impl<'ecx, T, F> std::ops::Deref for ExpandWith<'ecx, T, F> {
+    type Target = ExpandCtxt<'ecx>;
+
+    fn deref(&self) -> &Self::Target {
+        self.ecx
+    }
+}
+
+impl<'a, T: 'a, I, F, U: 'a, P: 'a> ToTokens for ExpandWith<'_, &'a T, F>
+where
+    F: Fn(&'a T) -> I,
+    I: IntoIterator<Item = Pair<U, &'a P>>,
+    for<'ecx> Expand<'ecx, U>: ToTokens,
+    P: ToTokens,
+{
+    fn to_tokens(&self, mut tokens: &mut TokenStream) {
+        for pair in (self.f)(self.value) {
+            let (value, punct) = pair.into_tuple();
+            let value = self.expand(value);
+            quote_each_token!(tokens #value #punct);
+        }
+    }
+}
+
+trait PairsExt<'a, T: 'a, P: 'a> {
+    fn map_value<U>(self, f: impl FnMut(&'a T) -> U) -> impl Iterator<Item = Pair<U, &'a P>>;
+}
+
+impl<'a, T: 'a, P: 'a> PairsExt<'a, T, P> for Pairs<'a, T, P> {
+    fn map_value<U>(self, mut f: impl FnMut(&'a T) -> U) -> impl Iterator<Item = Pair<U, &'a P>> {
+        self.map(move |pair| {
+            let (value, punct) = pair.into_tuple();
+            Pair::new(f(value), punct)
+        })
+    }
+}
+
+impl ToTokens for MirPatternFn {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        self.vis.to_tokens(tokens);
+        self.tk_fn.to_tokens(tokens);
+        self.ident.to_tokens(tokens);
+        self.generics.to_tokens(tokens);
+        self.paren.surround(tokens, |tokens| {
+            self.tcx.to_tokens(tokens);
+            self.tk_colon1.to_tokens(tokens);
+            self.tcx_ty.to_tokens(tokens);
+            self.tk_comma1.to_tokens(tokens);
+            self.patterns.to_tokens(tokens);
+            self.tk_colon2.to_tokens(tokens);
+            self.patterns_ty.to_tokens(tokens);
+            self.tk_comma2.to_tokens(tokens);
+        });
+        self.tk_arrow.to_tokens(tokens);
+        self.ret.to_tokens(tokens);
+        self.brace.surround(tokens, |tokens| {
+            let ecx = ExpandCtxt::new(&self.tcx, &self.patterns);
+            ecx.expand(&self.mir_pattern).to_tokens(tokens);
+            for stmt in &self.stmts {
+                stmt.to_tokens(tokens);
+            }
+        });
+    }
+}
+
+impl ToTokens for Expand<'_, &MirPattern> {
+    fn to_tokens(&self, mut tokens: &mut TokenStream) {
+        let statements = self.value.statements.iter().map(|statement| self.expand(statement));
+        quote_each_token!(tokens #(#statements)*);
+    }
+}
+
+impl ToTokens for Expand<'_, &Statement> {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        match self.value {
+            Statement::TypeDecl(type_decl) => self.expand(type_decl).to_tokens(tokens),
+            Statement::UsePath(use_path) => self.expand(use_path).to_tokens(tokens),
+            Statement::LocalDecl(local_decl) => self.expand(local_decl).to_tokens(tokens),
+            Statement::Assign(assign) => self.expand(assign).to_tokens(tokens),
+            Statement::Drop(drop) => self.expand(drop).to_tokens(tokens),
+        }
+    }
+}
+
+impl ToTokens for Expand<'_, &TypeDecl> {
+    fn to_tokens(&self, mut tokens: &mut TokenStream) {
+        let ExpandCtxt { tcx, patterns, symbols } = self.ecx;
+        let TypeDecl { ident, ty, .. } = self.value;
+        match ty {
+            TypeOrAny::Any(_) => {
+                let ty_ident = ident.as_ty();
+                let ty_var_ident = ident.as_ty_var();
+                symbols.lock().add_ty_var(ident.clone());
+                quote_each_token!(tokens
+                    let #ty_var_ident = #patterns.new_ty_var();
+                    let #ty_ident = #patterns.mk_var_ty(#tcx, #ty_var_ident);
+                );
+            },
+            TypeOrAny::Type(ty) => {
+                let ty_ident = ident.as_ty();
+                symbols.lock().add_type(ident.clone(), ty.clone());
+                let ty = self.expand(ty);
+                quote_each_token!(tokens let #ty_ident = #ty;);
+            },
+        };
+    }
+}
+impl ToTokens for Expand<'_, &UsePath> {
+    fn to_tokens(&self, _tokens: &mut TokenStream) {
+        todo!()
+    }
+}
+
+impl ToTokens for Expand<'_, &LocalDecl> {
+    fn to_tokens(&self, mut tokens: &mut TokenStream) {
+        let LocalDecl {
+            ident,
+            ty,
+            rvalue_or_call,
+            ..
+        } = self.value;
+        let ExpandCtxt { symbols, patterns, .. } = self.ecx;
+        symbols.lock().add_local(ident.clone(), ty.clone());
+        let ty = self.expand(ty);
+        let local = ident.as_local();
+        quote_each_token!(tokens let #local = #patterns.mk_local(#ty); );
+        self.expand(Assign {
+            place: &Place::Local(ident.clone().into()),
+            rvalue_or_call,
+        })
+        .to_tokens(tokens);
+    }
+}
+
+struct Assign<'a> {
+    place: &'a Place,
+    rvalue_or_call: &'a RvalueOrCall,
+}
+
+impl ToTokens for Expand<'_, &syntax::Assign> {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        self.expand(Assign {
+            place: &self.value.place,
+            rvalue_or_call: &self.value.rvalue_or_call,
+        })
+        .to_tokens(tokens);
+    }
+}
+
+impl ToTokens for Expand<'_, Assign<'_>> {
+    fn to_tokens(&self, mut tokens: &mut TokenStream) {
+        let ExpandCtxt { patterns, tcx, symbols } = self.ecx;
+        let Assign { place, rvalue_or_call } = self.value;
+        let local = place.local();
+        let stmt = local.as_stmt();
+        quote_each_token!(tokens let #stmt = );
+        let place = self.expand(place);
+        match rvalue_or_call {
+            RvalueOrCall::Rvalue(rvalue) => {
+                let rvalue = self.expand(rvalue);
+                quote_each_token!(tokens #patterns.mk_assign(#place, #rvalue); );
+            },
+            RvalueOrCall::Call(Call { func, operands }) => {
+                let func = self.expand(func);
+                let operands = self.expand(operands);
+                quote_each_token!(tokens #patterns.mk_fn_call(
+                    #tcx, #func, #operands, [/* TODO: generics */], #place,
+                ); );
+            },
+            RvalueOrCall::Any(_) => {
+                _ = symbols.lock().get_local(local);
+                let local = local.as_local();
+                quote_each_token!(tokens #patterns.mk_init(#local); );
+            },
+        }
+    }
+}
+
+impl ToTokens for Expand<'_, &Drop> {
+    fn to_tokens(&self, mut tokens: &mut TokenStream) {
+        let ExpandCtxt { patterns, .. } = self.ecx;
+        let Drop { ref place, .. } = self.value;
+        let stmt = place.local().as_stmt();
+        quote_each_token!(tokens let #stmt = #patterns.mk_drop(#place); );
+    }
+}
+
+trait RegionExt {
+    fn kind(&self) -> RegionKind;
+}
+
+impl RegionExt for Option<Region> {
+    fn kind(&self) -> RegionKind {
+        self.map_or(RegionKind::ReAny(Default::default()), |region| region.kind)
+    }
+}
+
+impl ToTokens for Expand<'_, &Type> {
+    fn to_tokens(&self, mut tokens: &mut TokenStream) {
+        let ExpandCtxt { tcx, patterns, symbols } = self.ecx;
+        match self.value {
+            Type::Array(TypeArray { box ty, len, .. }) => {
+                let ty = self.expand(ty);
+                let len = self.expand(len);
+                quote_each_token!(tokens #patterns.mk_array(#tcx, #ty, #len));
+            },
+            Type::Group(TypeGroup { box ty, .. }) | Type::Paren(TypeParen { box ty, .. }) => {
+                self.expand(ty).to_tokens(tokens);
+            },
+            Type::Never(_) => todo!(),
+            Type::Path(TypePath { qself: None, path }) if let Some(ident) = path.as_ident() => {
+                const PRIMITIVES: &[&str] = &[
+                    "u8", "u16", "u32", "u64", "u128", "usize", "i8", "i16", "i32", "i64", "i128", "isize", "bool",
+                    "str",
+                ];
+                if PRIMITIVES.iter().any(|ty| ident == ty) {
+                    quote_each_token!(tokens #patterns.primitive_types.#ident);
+                } else {
+                    _ = symbols.lock().get_type(ident);
+                    ident.as_ty().to_tokens(tokens);
+                }
+            },
+            Type::Path(TypePath { .. }) => todo!(),
+            Type::Ptr(TypePtr { mutability, box ty, .. }) => {
+                let ty = self.expand(ty);
+                let mutability = self.expand(*mutability);
+                quote_each_token!(tokens #patterns.mk_raw_ptr_ty(#tcx, #ty, #mutability));
+            },
+            Type::Reference(TypeReference {
+                region,
+                mutability,
+                box ty,
+                ..
+            }) => {
+                let region = self.expand(region.kind());
+                let ty = self.expand(ty);
+                let mutability = self.expand(*mutability);
+                quote_each_token!(tokens #patterns.mk_ref_ty(#tcx, #region, #ty, #mutability));
+            },
+            Type::Slice(TypeSlice { box ty, .. }) => {
+                let ty = self.expand(ty);
+                quote_each_token!(tokens #patterns.mk_slice_ty(#tcx, #ty));
+            },
+            Type::Tuple(_) => todo!(),
+        }
+    }
+}
+
+impl ToTokens for Expand<'_, &CallOperands> {
+    fn to_tokens(&self, _tokens: &mut TokenStream) {
+        todo!()
+    }
+}
+
+impl ToTokens for Expand<'_, &Rvalue> {
+    fn to_tokens(&self, mut tokens: &mut TokenStream) {
+        quote_each_token!(tokens ::rpl_mir_pattern::pat::Rvalue::);
+        match self.value {
+            Rvalue::Use(RvalueUse { operand, .. }) => {
+                let operand = self.expand(operand);
+                quote_each_token!(tokens Use(#operand));
+            },
+            Rvalue::Repeat(RvalueRepeat { operand, len, .. }) => {
+                let operand = self.expand(operand);
+                let len = self.expand(len);
+                quote_each_token!(tokens Repeat(#operand, #len));
+            },
+            Rvalue::Ref(RvalueRef {
+                region,
+                mutability,
+                place,
+                ..
+            }) => {
+                let region = self.expand(region.kind());
+                let mutability = self.expand(BorrowKind(*mutability));
+                let place = self.expand(place);
+                quote_each_token!(tokens Ref(#region, #mutability, #place));
+            },
+            Rvalue::AddressOf(RvalueAddrOf { mutability, place, .. }) => {
+                let mutability = self.expand(*mutability);
+                let place = self.expand(place);
+                quote_each_token!(tokens AddressOf(#mutability, #place));
+            },
+            Rvalue::Len(RvalueLen { place, .. }) => {
+                let place = self.expand(place);
+                quote_each_token!(tokens Len(#place));
+            },
+            Rvalue::Cast(RvalueCast {
+                operand, ty, cast_kind, ..
+            }) => {
+                let operand = self.expand(operand);
+                let ty = self.expand(ty);
+                let cast_kind = self.expand(*cast_kind);
+                quote_each_token!(tokens Cast(#cast_kind, #operand, #ty));
+            },
+            Rvalue::BinaryOp(RvalueBinOp { op, lhs, rhs, .. }) => {
+                let op = self.expand(*op);
+                let lhs = self.expand(lhs);
+                let rhs = self.expand(rhs);
+                quote_each_token!(tokens BinaryOp(#op, Box::new([#lhs, #rhs])));
+            },
+            Rvalue::NullaryOp(RvalueNullOp { op, ty, .. }) => {
+                let op = self.expand(*op);
+                let ty = self.expand(ty);
+                quote_each_token!(tokens NullaryOp(#op, #ty));
+            },
+            Rvalue::UnaryOp(RvalueUnOp { op, operand, .. }) => {
+                let op = self.expand(*op);
+                let operand = self.expand(operand);
+                quote_each_token!(tokens UnaryOp(#op, #operand));
+            },
+            Rvalue::Discriminant(RvalueDiscriminant { place, .. }) => {
+                let place = self.expand(place);
+                quote_each_token!(tokens Discriminant(#place));
+            },
+            Rvalue::Aggregate(aggregate) => {
+                let aggregate = self.expand(aggregate);
+                quote_each_token!(tokens Aggregate(#aggregate));
+            },
+        }
+    }
+}
+
+impl ToTokens for Expand<'_, &Operand> {
+    fn to_tokens(&self, mut tokens: &mut TokenStream) {
+        quote_each_token!(tokens ::rpl_mir_pattern::pat::);
+        match self.value {
+            Operand::Copy(OperandCopy { place, .. }) => {
+                let place = self.expand(place);
+                quote_each_token!(tokens Copy(#place));
+            },
+            Operand::Move(OperandMove { place, .. }) => {
+                let place = self.expand(place);
+                quote_each_token!(tokens Move(#place));
+            },
+            Operand::Constant(konst) => {
+                let konst = self.expand(konst);
+                quote_each_token!(tokens Constant(#konst));
+            },
+        }
+    }
+}
+
+impl ToTokens for Expand<'_, &Const> {
+    fn to_tokens(&self, _tokens: &mut TokenStream) {
+        todo!()
+    }
+}
+
+struct Projections<'a>(&'a Place);
+
+impl ToTokens for Expand<'_, Projections<'_>> {
+    fn to_tokens(&self, mut tokens: &mut TokenStream) {
+        if let Place::Local(_) = self.value.0 {
+            return;
+        }
+        quote_each_token!(tokens ::rpl_mir_pattern::pat::PlaceElem::);
+        let inner = match self.value.0 {
+            Place::Local(_) => return,
+            Place::Paren(PlaceParen { box place, .. }) => place,
+            Place::Deref(PlaceDeref { box place, .. }) => {
+                quote_each_token!(tokens Deref,);
+                place
+            },
+            Place::Field(PlaceField { box place, field, .. }) => {
+                let field = self.expand(field);
+                quote_each_token!(tokens Field(#field),);
+                place
+            },
+            Place::Index(PlaceIndex { box place, index, .. }) => {
+                let index = index.as_local();
+                quote_each_token!(tokens Index(#index),);
+                place
+            },
+            &Place::ConstIndex(PlaceConstIndex {
+                box ref place,
+                from_end,
+                index: syn::Index { index, .. },
+                ..
+            }) => {
+                let from_end = from_end.is_some();
+                quote_each_token!(tokens ConstIndex { offset: #index, from_end: #from_end },);
+                place
+            },
+            &Place::Subslice(PlaceSubslice {
+                box ref place,
+                from: syn::Index { index: from, .. },
+                from_end,
+                to: syn::Index { index: to, .. },
+                ..
+            }) => {
+                let from_end = from_end.is_some();
+                quote_each_token!(tokens Subslice { from: #from, to: #to, from_end: #from_end },);
+                place
+            },
+            Place::DownCast(PlaceDowncast { box place, variant, .. }) => {
+                let variant = self.expand(variant.as_symbol());
+                quote_each_token!(tokens Downcast(#variant),);
+                place
+            },
+        };
+        self.expand(Projections(inner)).to_tokens(tokens);
+    }
+}
+
+impl ToTokens for Expand<'_, &syn::Member> {
+    fn to_tokens(&self, mut tokens: &mut TokenStream) {
+        quote_each_token!(tokens ::rpl_mir_pattern::pat::Field::);
+        match self.value {
+            syn::Member::Named(name) => {
+                let name = self.expand(name.as_symbol());
+                quote_each_token!(tokens Named(#name));
+            },
+            &syn::Member::Unnamed(syn::Index { index, .. }) => {
+                quote_each_token!(tokens Unnamed(#index.into()));
+            },
+        }
+    }
+}
+
+impl ToTokens for Expand<'_, &Place> {
+    fn to_tokens(&self, mut tokens: &mut TokenStream) {
+        let ExpandCtxt { tcx, patterns, .. } = self.ecx;
+        if let Place::Local(PlaceLocal { local }) = self.value {
+            let local = local.as_local();
+            quote_each_token!(tokens #local.into_place());
+        } else {
+            let local = self.value.local().as_local();
+            let projections = self.expand(Projections(self.value));
+            quote_each_token!(tokens #patterns.mk_place(#local, (#tcx, &[#projections])));
+        }
+    }
+}
+
+struct IdentSymbol<'a>(&'a Ident);
+
+impl ToTokens for Expand<'_, IdentSymbol<'_>> {
+    fn to_tokens(&self, mut tokens: &mut TokenStream) {
+        let ident = self.value.0.to_string();
+        quote_each_token!(tokens ::rustc_span::Symbol::intern(#ident));
+    }
+}
+
+impl ToTokens for Expand<'_, &RvalueAggregate> {
+    fn to_tokens(&self, mut tokens: &mut TokenStream) {
+        quote_each_token!(tokens ::rpl_mir_pattern::pat::AggKind::);
+        match self.value {
+            RvalueAggregate::Array(AggregateArray { box ty, operands, .. }) => {
+                let ty = self.expand(ty);
+                let operands = self.expand_punctuated(&operands.operands);
+                quote_each_token!(tokens Array(#ty), [#operands].into_iter().collect());
+            },
+            RvalueAggregate::Tuple(AggregateTuple { operands }) => {
+                let operands = self.expand_punctuated(&operands.operands);
+                quote_each_token!(tokens Tuple, [#operands].into_iter().collect());
+            },
+            RvalueAggregate::Adt(AggregateAdt {
+                adt,
+                fields: StructFields { fields, .. },
+            }) => {
+                let adt = self.expand(adt);
+                let operands = self.expand_punctuated_mapped(fields, |f| &f.operand);
+                let fields = self.expand_punctuated_mapped(fields, |f| f.ident.as_symbol());
+                quote_each_token!(tokens
+                    Adt(#adt, [/* TODO: generic argmuents */], [#fields].into_iter().collect()),
+                    [#operands].into_iter().collect(),
+                );
+            },
+            RvalueAggregate::RawPtr(AggregateRawPtr {
+                ty: TypePtr { mutability, box ty, .. },
+                ptr,
+                metadata,
+                ..
+            }) => {
+                let ty = self.expand(ty);
+                let mutability = self.expand(*mutability);
+                let ptr = self.expand(ptr);
+                let metadata = self.expand(metadata);
+                quote_each_token!(tokens RawPtr(#ty, #mutability), [#ptr, #metadata].into_iter().collect());
+            },
+        }
+    }
+}
+
+impl ToTokens for Expand<'_, &Path> {
+    fn to_tokens(&self, _tokens: &mut TokenStream) {
+        todo!()
+    }
+}
+
+impl ToTokens for Expand<'_, RegionKind> {
+    fn to_tokens(&self, mut tokens: &mut TokenStream) {
+        quote_each_token!(tokens ::rpl_mir_pattern::pat::RegionKind::);
+        match self.value {
+            RegionKind::ReAny(_) => quote_token!(ReAny tokens),
+            RegionKind::ReStatic(_) => quote_token!(ReStatic tokens),
+        }
+    }
+}
+
+struct BorrowKind(Mutability);
+
+impl ToTokens for Expand<'_, BorrowKind> {
+    fn to_tokens(&self, mut tokens: &mut TokenStream) {
+        quote_each_token!(tokens ::rustc_middle::mir::BorrowKind::);
+        match self.value.0 {
+            Mutability::Not => {
+                quote_each_token!(tokens Shared);
+            },
+            Mutability::Mut(_) => {
+                quote_each_token!(tokens Mut { kind: ::rustc_middle::mir::MutBorrowKind::Default });
+            },
+        }
+    }
+}
+
+impl ToTokens for Expand<'_, Mutability> {
+    fn to_tokens(&self, mut tokens: &mut TokenStream) {
+        quote_each_token!(tokens ::rustc_middle::mir::Mutability::);
+        match self.value {
+            Mutability::Not => quote_token!(Not tokens),
+            Mutability::Mut(_) => quote_token!(Mut tokens),
+        }
+    }
+}
+
+impl ToTokens for Expand<'_, PtrMutability> {
+    fn to_tokens(&self, mut tokens: &mut TokenStream) {
+        quote_each_token!(tokens ::rustc_middle::mir::Mutability::);
+        match self.value {
+            PtrMutability::Const(_) => quote_token!(Not tokens),
+            PtrMutability::Mut(_) => quote_token!(Mut tokens),
+        }
+    }
+}
+
+impl ToTokens for Expand<'_, CastKind> {
+    fn to_tokens(&self, mut tokens: &mut TokenStream) {
+        let value = self.value;
+        quote_each_token!(tokens ::rustc_middle::mir::CastKind::#value);
+    }
+}
+
+impl ToTokens for Expand<'_, BinOp> {
+    fn to_tokens(&self, mut tokens: &mut TokenStream) {
+        let value = self.value;
+        quote_each_token!(tokens ::rustc_middle::mir::BinOp::#value);
+    }
+}
+
+impl ToTokens for Expand<'_, UnOp> {
+    fn to_tokens(&self, mut tokens: &mut TokenStream) {
+        let value = self.value;
+        quote_each_token!(tokens ::rustc_middle::mir::UnOp::#value);
+    }
+}
+
+impl ToTokens for Expand<'_, NullOp> {
+    fn to_tokens(&self, mut tokens: &mut TokenStream) {
+        let value = self.value;
+        quote_each_token!(tokens ::rustc_middle::mir::NullOp::#value);
+    }
+}

--- a/crates/rpl_mir_pattern/expand/src/lib.rs
+++ b/crates/rpl_mir_pattern/expand/src/lib.rs
@@ -1,0 +1,25 @@
+#![feature(rustc_private)]
+#![feature(map_try_insert)]
+#![feature(box_patterns)]
+#![feature(if_let_guard)]
+#![feature(impl_trait_in_fn_trait_return)]
+
+extern crate rpl_mir_pattern_syntax as syntax;
+
+extern crate rustc_data_structures;
+extern crate rustc_driver;
+extern crate rustc_hash;
+extern crate rustc_index;
+
+pub(crate) mod expand;
+mod parse;
+pub(crate) mod symbol_table;
+
+#[cfg(test)]
+mod tests;
+
+pub use expand::expand;
+#[cfg(test)]
+pub(crate) use expand::{expand_impl, Expand};
+pub use parse::MirPatternFn;
+pub use symbol_table::SymbolTable;

--- a/crates/rpl_mir_pattern/expand/src/parse.rs
+++ b/crates/rpl_mir_pattern/expand/src/parse.rs
@@ -1,0 +1,112 @@
+use syn::parse::{Parse, ParseStream};
+use syn::{token, Ident};
+use syntax::MirPattern;
+
+mod kw {
+    syn::custom_keyword!(mir_pattern);
+}
+
+#[allow(dead_code)]
+enum Delimiter {
+    Brace(token::Brace),
+    Paren(token::Paren),
+    Bracket(token::Bracket),
+}
+
+#[derive(thiserror::Error, Debug)]
+enum ParseError {
+    #[error("expect `(`, `[`, or `{{")]
+    ExpectDelimiter,
+}
+
+pub struct MirPatternFn {
+    pub vis: syn::Visibility,
+    pub(crate) tk_fn: syn::Token![fn],
+    pub ident: Ident,
+    pub generics: syn::Generics,
+    pub(crate) paren: token::Paren,
+    pub tcx: Ident,
+    pub(crate) tk_colon1: syn::Token![:],
+    pub tcx_ty: syn::Type,
+    pub(crate) tk_comma1: syn::Token![,],
+    pub patterns: Ident,
+    pub(crate) tk_colon2: syn::Token![:],
+    pub patterns_ty: syn::Type,
+    pub(crate) tk_comma2: Option<syn::Token![,]>,
+    pub(crate) tk_arrow: syn::Token![->],
+    pub ret: syn::Type,
+    pub(crate) brace: token::Brace,
+    _kw_mir_pattern: kw::mir_pattern,
+    _tk_bang: syn::Token![!],
+    _delim: Delimiter,
+    pub mir_pattern: MirPattern,
+    _tk_semi: Option<syn::Token![;]>,
+    pub stmts: Vec<syn::Stmt>,
+}
+
+impl Parse for MirPatternFn {
+    fn parse(input: ParseStream<'_>) -> syn::Result<Self> {
+        use Delimiter::*;
+        let vis = input.parse()?;
+        let tk_fn = input.parse()?;
+        let ident = input.parse()?;
+        let generics = input.parse()?;
+        let params;
+        let paren = syn::parenthesized!(params in input);
+        let tcx = params.parse()?;
+        let tk_colon1 = params.parse()?;
+        let tcx_ty = params.parse()?;
+        let tk_comma1 = params.parse()?;
+        let patterns = params.parse()?;
+        let tk_colon2 = params.parse()?;
+        let patterns_ty = params.parse()?;
+        let tk_comma2 = params.parse()?;
+        drop(params);
+        let tk_arrow = input.parse()?;
+        let ret = input.parse()?;
+        let body;
+        let brace = syn::braced!(body in input);
+        let kw_mir_pattern = body.parse()?;
+        let tk_bang = body.parse()?;
+        let pattern;
+        let delim = if body.peek(token::Paren) {
+            Paren(syn::parenthesized!(pattern in body))
+        } else if body.peek(token::Brace) {
+            Brace(syn::braced!(pattern in body))
+        } else if body.peek(token::Bracket) {
+            Bracket(syn::bracketed!(pattern in body))
+        } else {
+            return Err(body.error(ParseError::ExpectDelimiter));
+        };
+        let mir_pattern = pattern.parse()?;
+        let tk_semi = match delim {
+            Paren(_) | Bracket(_) => Some(body.parse()?),
+            Brace(_) => body.parse()?,
+        };
+        let stmts = body.call(syn::Block::parse_within)?;
+        Ok(MirPatternFn {
+            vis,
+            tk_fn,
+            ident,
+            generics,
+            paren,
+            tcx,
+            tk_colon1,
+            tcx_ty,
+            tk_comma1,
+            patterns,
+            tk_colon2,
+            patterns_ty,
+            tk_comma2,
+            tk_arrow,
+            ret,
+            brace,
+            _kw_mir_pattern: kw_mir_pattern,
+            _tk_bang: tk_bang,
+            _delim: delim,
+            mir_pattern,
+            _tk_semi: tk_semi,
+            stmts,
+        })
+    }
+}

--- a/crates/rpl_mir_pattern/expand/src/symbol_table.rs
+++ b/crates/rpl_mir_pattern/expand/src/symbol_table.rs
@@ -1,0 +1,102 @@
+use std::panic::panic_any;
+
+use proc_macro2::{Group, Span, TokenStream};
+use rustc_hash::FxHashMap;
+use syn::Ident;
+use syntax::{Path, Type};
+
+#[derive(thiserror::Error, Debug)]
+#[allow(clippy::enum_variant_names)]
+pub(crate) enum ResolveError {
+    #[error("type or path named by `{0}` is already declared")]
+    TypeOrAlreadyDeclared(String),
+    #[error("type or path named by `{0}` is not declared")]
+    TypeOrPathNotDeclared(String),
+    #[error("local `{0}` is not declared")]
+    LocalNotDeclared(String),
+}
+
+#[derive(Default)]
+pub struct SymbolTable {
+    locals: FxHashMap<Ident, Type>,
+    types: FxHashMap<Ident, TypeKind>,
+}
+
+pub enum TypeKind {
+    TyVar(Span),
+    Type(Type),
+    Path(Path),
+}
+
+impl From<Type> for TypeKind {
+    fn from(ty: Type) -> Self {
+        TypeKind::Type(ty)
+    }
+}
+
+impl From<Path> for TypeKind {
+    fn from(path: Path) -> Self {
+        TypeKind::Path(path)
+    }
+}
+
+impl quote::ToTokens for TypeKind {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        match self {
+            &TypeKind::TyVar(span) => {
+                let mut group = Group::new(proc_macro2::Delimiter::None, TokenStream::new());
+                group.set_span(span);
+                group.to_tokens(tokens);
+            },
+            TypeKind::Type(ty) => ty.to_tokens(tokens),
+            TypeKind::Path(path) => path.to_tokens(tokens),
+        }
+    }
+}
+
+impl SymbolTable {
+    fn add_type_impl(&mut self, ident: Ident, ty: TypeKind) {
+        self.types
+            .try_insert(ident.clone(), ty)
+            .map(|_| {})
+            .unwrap_or_else(|entry| {
+                panic_any(syn::Error::new_spanned(
+                    entry.entry.get(),
+                    ResolveError::TypeOrAlreadyDeclared(ident.to_string()),
+                ))
+            })
+    }
+    pub fn add_ty_var(&mut self, ident: Ident) {
+        let span = ident.span();
+        self.add_type_impl(ident, TypeKind::TyVar(span));
+    }
+    pub fn add_type(&mut self, ident: Ident, ty: Type) {
+        self.add_type_impl(ident, ty.into());
+    }
+    pub fn get_type(&self, ident: &Ident) -> &TypeKind {
+        self.types.get(ident).unwrap_or_else(|| {
+            panic_any(syn::Error::new(
+                ident.span(),
+                ResolveError::TypeOrPathNotDeclared(ident.to_string()),
+            ))
+        })
+    }
+    pub fn add_local(&mut self, ident: Ident, ty: Type) {
+        self.locals.insert(ident, ty);
+    }
+    pub fn get_local(&self, ident: &Ident) -> &Type {
+        self.locals.get(ident).unwrap_or_else(|| {
+            panic_any(syn::Error::new(
+                ident.span(),
+                ResolveError::LocalNotDeclared(ident.to_string()),
+            ))
+        })
+    }
+    pub fn add_path(&mut self, path: Path) {
+        let ident = path
+            .ident()
+            .expect("invalid path without an identifier at the end")
+            .clone();
+        self.add_type_impl(ident, path.into());
+    }
+}

--- a/crates/rpl_mir_pattern/expand/src/tests.rs
+++ b/crates/rpl_mir_pattern/expand/src/tests.rs
@@ -1,0 +1,155 @@
+use proc_macro2::TokenStream;
+use quote::{quote, ToTokens};
+use syn::parse::Parse;
+use syntax::*;
+
+#[track_caller]
+fn test_pass<T: Parse + std::panic::RefUnwindSafe>(input: TokenStream, output: TokenStream)
+where
+    for<'ecx, 'a> crate::Expand<'ecx, &'a T>: ToTokens,
+{
+    let value: T = syn::parse2(input).unwrap();
+    let tcx = syn::parse_quote!(tcx);
+    let patterns = syn::parse_quote!(patterns);
+    let expanded = std::panic::catch_unwind(|| crate::expand_impl(&tcx, &patterns, &value))
+        .map_err(|err| err.downcast::<syn::Error>().unwrap())
+        .unwrap();
+    assert_eq!(expanded.to_string(), output.to_string());
+}
+
+macro_rules! pass {
+    ($test_struct:ident!( $( $tt:tt )* ), $($output:tt)*) => {
+        test_pass::<$test_struct>(quote!($($tt)*), $($output)*);
+    };
+    ($test_struct:ident!{ $( $tt:tt )* }, $($output:tt)*) => {
+        pass!($test_struct!( $($tt)* ), $($output)*);
+    };
+    ($test_struct:ident![ $( $tt:tt )* ], $($output:tt)*) => {
+        pass!($test_struct!( $($tt)* ), $($output)*);
+    };
+}
+
+#[test]
+fn test_type_decl() {
+    pass!(
+        TypeDecl!( type T = ...; ),
+        quote! {
+            let T_ty_var = patterns.new_ty_var();
+            let T_ty = patterns.mk_var_ty(tcx, T_ty_var);
+        },
+    );
+}
+
+#[test]
+fn test_mir_pattern() {
+    pass!(
+        MirPattern! {
+            type T = ...;
+            type SliceT = [T];
+            type RefSliceT = &SliceT;
+            type PtrSliceT = *const SliceT;
+            type PtrU8 = *const u8;
+            type SliceU8 = [u8];
+            type PtrSliceU8 = *const SliceU8;
+            type RefSliceU8 = &SliceU8;
+
+            let from_slice: SliceT = ...;
+            let from_raw_slice: PtrSliceT = &raw const *from_slice;
+            let from_len: usize = Len(from_slice);
+            let ty_size: usize = SizeOf(T);
+            let to_ptr: PtrU8 = from_ptr as PtrU8 (PtrToPtr);
+            let to_len: usize = Mul(from_len, ty_size);
+            let to_raw_slice: PtrSliceU8 = *const SliceU8 from (to_ptr, t_len);
+            let to_slice: RefSliceU8 = &*to_raw_slice;
+        },
+        quote! {
+            let T_ty_var = patterns.new_ty_var();
+            let T_ty = patterns.mk_var_ty(tcx, T_ty_var);
+            let SliceT_ty = patterns.mk_slice_ty(tcx, T_ty);
+            let RefSliceT_ty = patterns.mk_ref_ty(
+                tcx,
+                ::rpl_mir_pattern::pat::RegionKind::ReAny,
+                SliceT_ty,
+                ::rustc_middle::mir::Mutability::Not
+            );
+            let PtrSliceT_ty = patterns.mk_raw_ptr_ty(
+                tcx, SliceT_ty, ::rustc_middle::mir::Mutability::Not);
+            let PtrU8_ty = patterns.mk_raw_ptr_ty(
+                tcx, patterns.primitive_types.u8, ::rustc_middle::mir::Mutability::Not);
+            let SliceU8_ty = patterns.mk_slice_ty(tcx, patterns.primitive_types.u8);
+            let PtrSliceU8_ty = patterns.mk_raw_ptr_ty(
+                tcx, SliceU8_ty, ::rustc_middle::mir::Mutability::Not);
+            let RefSliceU8_ty = patterns.mk_ref_ty(
+                tcx,
+                ::rpl_mir_pattern::pat::RegionKind::ReAny,
+                SliceU8_ty,
+                ::rustc_middle::mir::Mutability::Not
+            );
+            let from_slice_local = patterns.mk_local(SliceT_ty);
+            let from_slice_stmt = patterns.mk_init(from_slice_local);
+            let from_raw_slice_local = patterns.mk_local(PtrSliceT_ty);
+            let from_raw_slice_stmt = patterns.mk_assign(
+                from_raw_slice_local.into_place(),
+                ::rpl_mir_pattern::pat::Rvalue::AddressOf(
+                    ::rustc_middle::mir::Mutability::Not,
+                    patterns.mk_place(
+                        from_slice_local,
+                        (tcx, &[::rpl_mir_pattern::pat::PlaceElem::Deref,])
+                    )
+                )
+            );
+            let from_len_local = patterns.mk_local(patterns.primitive_types.usize);
+            let from_len_stmt = patterns.mk_assign(
+                from_len_local.into_place(),
+                ::rpl_mir_pattern::pat::Rvalue::Len(from_slice_local.into_place())
+            );
+            let ty_size_local = patterns.mk_local(patterns.primitive_types.usize);
+            let ty_size_stmt = patterns.mk_assign(
+                ty_size_local.into_place(),
+                ::rpl_mir_pattern::pat::Rvalue::NullaryOp(::rustc_middle::mir::NullOp::SizeOf, T_ty)
+            );
+            let to_ptr_local = patterns.mk_local(PtrU8_ty);
+            let to_ptr_stmt = patterns.mk_assign(
+                to_ptr_local.into_place(),
+                ::rpl_mir_pattern::pat::Rvalue::Cast(
+                    ::rustc_middle::mir::CastKind::PtrToPtr,
+                    ::rpl_mir_pattern::pat::Copy(from_ptr_local.into_place()),
+                    PtrU8_ty
+                )
+            );
+            let to_len_local = patterns.mk_local(patterns.primitive_types.usize);
+            let to_len_stmt = patterns.mk_assign(
+                to_len_local.into_place(),
+                ::rpl_mir_pattern::pat::Rvalue::BinaryOp(
+                    ::rustc_middle::mir::BinOp::Mul,
+                    Box::new([
+                        ::rpl_mir_pattern::pat::Copy(from_len_local.into_place()),
+                        ::rpl_mir_pattern::pat::Copy(ty_size_local.into_place())
+                    ])
+                )
+            );
+            let to_raw_slice_local = patterns.mk_local(PtrSliceU8_ty);
+            let to_raw_slice_stmt = patterns.mk_assign(
+                to_raw_slice_local.into_place(),
+                ::rpl_mir_pattern::pat::Rvalue::Aggregate(
+                    ::rpl_mir_pattern::pat::AggKind::RawPtr(SliceU8_ty, ::rustc_middle::mir::Mutability::Not),
+                    [
+                        ::rpl_mir_pattern::pat::Copy(to_ptr_local.into_place()),
+                        ::rpl_mir_pattern::pat::Copy(t_len_local.into_place())
+                    ]
+                    .into_iter()
+                    .collect()
+                )
+            );
+            let to_slice_local = patterns.mk_local(RefSliceU8_ty);
+            let to_slice_stmt = patterns.mk_assign(
+                to_slice_local.into_place(),
+                ::rpl_mir_pattern::pat::Rvalue::Ref(
+                    ::rpl_mir_pattern::pat::RegionKind::ReAny,
+                    ::rustc_middle::mir::BorrowKind::Shared,
+                    patterns.mk_place(to_raw_slice_local, (tcx, &[::rpl_mir_pattern::pat::PlaceElem::Deref,]))
+                )
+            );
+        },
+    );
+}

--- a/crates/rpl_mir_pattern/src/lib.rs
+++ b/crates/rpl_mir_pattern/src/lib.rs
@@ -11,6 +11,7 @@ extern crate rustc_data_structures;
 extern crate rustc_driver;
 extern crate rustc_errors;
 extern crate rustc_fluent_macro;
+extern crate rustc_hash;
 extern crate rustc_hir;
 extern crate rustc_index;
 extern crate rustc_macros;
@@ -25,9 +26,10 @@ pub mod pattern;
 use std::iter::zip;
 
 use rustc_index::bit_set::BitSet;
-use rustc_index::Idx;
+use rustc_index::{Idx, IndexSlice};
 use rustc_middle::ty::TyCtxt;
 use rustc_middle::{mir, ty};
+use rustc_target::abi::FieldIdx;
 
 pub use crate::pattern as pat;
 
@@ -42,7 +44,7 @@ impl<'tcx> CheckMirCtxt<'tcx> {
         Self {
             tcx,
             body,
-            patterns: Default::default(),
+            patterns: pat::Patterns::new(tcx),
         }
     }
     #[instrument(level = "info", skip(self), fields(def_id = ?self.body.source.def_id()))]
@@ -290,10 +292,7 @@ impl<'tcx> CheckMirCtxt<'tcx> {
                 op_pat == op && self.match_operand(operand_pat, operand)
             },
             (pat::Rvalue::Aggregate(agg_kind_pat, operands_pat), mir::Rvalue::Aggregate(box agg_kind, operands)) => {
-                self.match_agg_kind(agg_kind_pat, agg_kind)
-                    && operands_pat.len() == operands.len()
-                    && core::iter::zip(operands_pat, operands)
-                        .all(|(operand_pat, operand)| self.match_operand(operand_pat, operand))
+                self.match_aggregate(agg_kind_pat, operands_pat, agg_kind, operands)
             },
             (&pat::Rvalue::ShallowInitBox(ref operand_pat, ty_pat), &mir::Rvalue::ShallowInitBox(ref operand, ty)) => {
                 self.match_operand(operand_pat, operand) && self.match_ty(ty_pat, ty)
@@ -305,36 +304,15 @@ impl<'tcx> CheckMirCtxt<'tcx> {
     }
 
     pub fn match_operand(&self, pat: &pat::Operand<'tcx>, operand: &mir::Operand<'tcx>) -> bool {
-        let matched = match (pat, operand) {
-            (&pat::Operand::Copy(place_pat), &mir::Operand::Copy(place))
-            | (&pat::Operand::Move(place_pat), &mir::Operand::Move(place)) => self.match_place(place_pat, place),
-            (pat::Operand::Constant(konst_pat), mir::Operand::Constant(box konst)) => {
-                self.match_const_operand(konst_pat, konst.const_)
-            },
-            _ => return false,
-        };
-        debug!(?pat, ?operand, matched, "match_operand");
-        matched
+        self.patterns.match_operand(self.tcx, self.body, pat, operand)
     }
 
     pub fn match_const_operand(&self, pat: &pat::ConstOperand<'tcx>, operand: mir::Const<'tcx>) -> bool {
-        match (pat, operand) {
-            (&pat::ConstOperand::Ty(ty_pat, konst_pat), mir::Const::Ty(ty, konst)) => {
-                self.match_ty(ty_pat, ty) && self.match_const(konst_pat, konst)
-            },
-            (&pat::ConstOperand::Val(value_pat, ty_pat), mir::Const::Val(value, ty)) => {
-                self.match_const_value(value_pat, value) && self.match_ty(ty_pat, ty)
-            },
-            _ => false,
-        }
+        self.patterns.match_const_operand(self.tcx, pat, operand)
     }
 
     pub fn match_const_value(&self, pat: pat::ConstValue, value: mir::ConstValue<'tcx>) -> bool {
-        match (pat, value) {
-            (pattern::ConstValue::Scalar(scalar_pat), mir::ConstValue::Scalar(scalar)) => scalar_pat == scalar,
-            (pattern::ConstValue::ZeroSized, mir::ConstValue::ZeroSized) => true,
-            _ => false,
-        }
+        self.patterns.match_const_value(pat, value)
     }
 
     pub fn match_operands(
@@ -352,8 +330,15 @@ impl<'tcx> CheckMirCtxt<'tcx> {
         }
     }
 
-    fn match_agg_kind(&self, pat: &pat::AggKind<'tcx>, agg_kind: &mir::AggregateKind<'tcx>) -> bool {
-        self.patterns.match_agg_kind(self.tcx, pat, agg_kind)
+    fn match_aggregate(
+        &self,
+        agg_kind_pat: &pat::AggKind<'tcx>,
+        operands_pat: &[pat::Operand<'tcx>],
+        agg_kind: &mir::AggregateKind<'tcx>,
+        operands: &IndexSlice<FieldIdx, mir::Operand<'tcx>>,
+    ) -> bool {
+        self.patterns
+            .match_aggregate(self.tcx, self.body, agg_kind_pat, operands_pat, agg_kind, operands)
     }
 
     fn match_ty(&self, ty_pat: pat::Ty<'tcx>, ty: ty::Ty<'tcx>) -> bool {

--- a/crates/rpl_mir_pattern/src/pattern/pretty.rs
+++ b/crates/rpl_mir_pattern/src/pattern/pretty.rs
@@ -23,11 +23,7 @@ fn fmt_projection<'tcx>(f: &mut fmt::Formatter<'_>, place: Place<'tcx>, proj: &P
         PlaceElem::Deref => write!(f, "(*{place:?})"),
         PlaceElem::Field(field) => write!(f, "({place:?}.{field:?})"),
         PlaceElem::Index(local) => write!(f, "({place:?}[{local:?}])"),
-        &PlaceElem::ConstantIndex {
-            offset,
-            min_length: _,
-            from_end,
-        } => {
+        &PlaceElem::ConstantIndex { offset, from_end } => {
             if from_end {
                 write!(f, "({place:?}[{offset}])")
             } else {
@@ -104,6 +100,8 @@ impl<'tcx> fmt::Debug for TyKind<'tcx> {
             Self::Uint(uint) => uint.fmt(f),
             Self::Int(int) => int.fmt(f),
             Self::Float(float) => float.fmt(f),
+            Self::Bool => f.write_str("bool"),
+            Self::Str => f.write_str("str"),
             Self::FnDef(path, args) => write!(f, "{path:?}{args:?}"),
             Self::Alias(_alias_kind, path, args) => write!(f, "{path:?}{args:?}"),
         }
@@ -137,7 +135,7 @@ impl fmt::Debug for RegionKind {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::ReStatic => f.write_str("'static"),
-            Self::ReErased => f.write_str("'_"),
+            Self::ReAny => f.write_str("'_"),
         }
     }
 }
@@ -146,7 +144,7 @@ impl fmt::Display for RegionKind {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::ReStatic => f.write_str("'static"),
-            Self::ReErased => Ok(()),
+            Self::ReAny => Ok(()),
         }
     }
 }
@@ -217,7 +215,7 @@ impl fmt::Debug for Field {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::Named(sym) => write!(f, "{sym}"),
-            Self::Relative(field) => field.fmt(f),
+            Self::Unnamed(field) => field.fmt(f),
         }
     }
 }

--- a/crates/rpl_mir_pattern/src/pattern/visitor.rs
+++ b/crates/rpl_mir_pattern/src/pattern/visitor.rs
@@ -91,7 +91,7 @@ impl<'tcx> PatternSuperVisitable<'tcx> for Ty<'tcx> {
             },
             &TyKind::RawPtr(ty, _) => vis.visit_ty(ty),
             &TyKind::Adt(_, args) => vis.visit_generic_args(args),
-            TyKind::Uint(_) | TyKind::Int(_) | TyKind::Float(_) => {},
+            TyKind::Uint(_) | TyKind::Int(_) | TyKind::Float(_) | TyKind::Str | TyKind::Bool => {},
             &TyKind::FnDef(ref path, args) => {
                 vis.visit_path(path);
                 vis.visit_generic_args(args);

--- a/crates/rpl_mir_pattern/syntax/src/to_tokens.rs
+++ b/crates/rpl_mir_pattern/syntax/src/to_tokens.rs
@@ -36,7 +36,7 @@ macro_rules! ToTokens {
 impl AsRef<str> for Region {
     fn as_ref(&self) -> &str {
         match self.kind {
-            RegionKind::ReErased(_) => "'_",
+            RegionKind::ReAny(_) => "'_",
             RegionKind::ReStatic(_) => "'static",
         }
     }
@@ -76,7 +76,7 @@ impl ToTokens for TypeSlice {
 
 impl ToTokens for TypeGroup {
     fn to_tokens(&self, tokens: &mut TokenStream) {
-        self.group.surround(tokens, |tokens| self.ty.to_tokens(tokens));
+        self.tk_group.surround(tokens, |tokens| self.ty.to_tokens(tokens));
     }
 }
 
@@ -253,16 +253,6 @@ impl ToTokens for AggregateArray {
         });
         self.kw_from.to_tokens(tokens);
         self.operands.to_tokens(tokens);
-    }
-}
-
-impl ToTokens for StructField {
-    fn to_tokens(&self, tokens: &mut TokenStream) {
-        self.ident.to_tokens(tokens);
-        if let Some((tk_colon, operand)) = &self.operand {
-            tk_colon.to_tokens(tokens);
-            operand.to_tokens(tokens);
-        }
     }
 }
 

--- a/crates/rpl_patterns/src/cve_2020_25016.rs
+++ b/crates/rpl_patterns/src/cve_2020_25016.rs
@@ -4,8 +4,7 @@ use rustc_hir as hir;
 use rustc_hir::def_id::LocalDefId;
 use rustc_hir::intravisit::{self, Visitor};
 use rustc_middle::hir::nested_filter::All;
-use rustc_middle::ty::{Ty, TyCtxt};
-use rustc_middle::{mir, ty};
+use rustc_middle::ty::{self, Ty, TyCtxt};
 use rustc_span::{sym, Span, Symbol};
 
 use rpl_mir_pattern::{pat, CheckMirCtxt};
@@ -103,137 +102,42 @@ struct Pattern {
     cast_to_mut: pat::PatternIdx,
 }
 
-/// patterns:
-/// ```ignore
-/// let from_slice: &[T] = ...;
-/// let from_raw_slice: *const [T] = &raw const *from_slice;
-/// let from_len: usize = Len(from_slice);
-/// let ty_size: usize = SizeOf($T);
-/// let to_ptr: *const u8 = from_ptr as *const u8;
-/// let to_len: usize = Mul(from_len, ty_size);
-/// let to_raw_slice: *const [u8] = Aggregate(*const [u8], [to_ptr, t_len]);
-/// let to_slice: &u8 = &*to_raw_slice;
-/// ```
+#[rpl_macros::mir_pattern]
 fn pattern<'tcx>(tcx: TyCtxt<'tcx>, patterns: &mut pat::Patterns<'tcx>) -> Pattern {
-    let ty_var = patterns.new_ty_var();
-    let ty = patterns.mk_ty(tcx, pat::TyKind::TyVar(ty_var));
-    let slice_ty = patterns.mk_ty(tcx, pat::TyKind::Slice(ty));
-    let ref_slice_ty = patterns.mk_ty(
-        tcx,
-        pat::TyKind::Ref(pat::RegionKind::ReErased, slice_ty, mir::Mutability::Not),
-    );
-    let mut_slice_ty = patterns.mk_ty(
-        tcx,
-        pat::TyKind::Ref(pat::RegionKind::ReErased, slice_ty, mir::Mutability::Mut),
-    );
-    let raw_slice_ty = patterns.mk_ty(tcx, pat::TyKind::RawPtr(slice_ty, mir::Mutability::Not));
-    let raw_mut_slice_ty = patterns.mk_ty(tcx, pat::TyKind::RawPtr(slice_ty, mir::Mutability::Mut));
-    let u8_ty = patterns.mk_ty(tcx, pat::TyKind::Uint(ty::UintTy::U8));
-    let usize_ty = patterns.mk_ty(tcx, pat::TyKind::Uint(ty::UintTy::Usize));
-    let u8_ptr_ty = patterns.mk_ty(tcx, pat::TyKind::RawPtr(u8_ty, mir::Mutability::Not));
-    let u8_mut_ptr_ty = patterns.mk_ty(tcx, pat::TyKind::RawPtr(u8_ty, mir::Mutability::Mut));
-    let u8_slice_ty = patterns.mk_ty(tcx, pat::TyKind::Slice(u8_ty));
-    let u8_slice_ptr_ty = patterns.mk_ty(tcx, pat::TyKind::RawPtr(u8_slice_ty, mir::Mutability::Not));
-    let u8_slice_mut_ptr_ty = patterns.mk_ty(tcx, pat::TyKind::RawPtr(u8_slice_ty, mir::Mutability::Mut));
-    let u8_slice_ref_ty = patterns.mk_ty(
-        tcx,
-        pat::TyKind::Ref(pat::RegionKind::ReErased, u8_slice_ty, mir::Mutability::Not),
-    );
-    let u8_slice_mut_ty = patterns.mk_ty(
-        tcx,
-        pat::TyKind::Ref(pat::RegionKind::ReErased, u8_slice_ty, mir::Mutability::Mut),
-    );
+    mir_pattern! {
+        type T = ...;
 
-    let from_slice = patterns.mk_local(ref_slice_ty);
-    let from_mut_slice = patterns.mk_local(mut_slice_ty);
-    let from_raw = patterns.mk_local(raw_slice_ty).into_place();
-    let from_raw_mut = patterns.mk_local(raw_mut_slice_ty).into_place();
-    let to_ptr = patterns.mk_local(u8_ptr_ty).into_place();
-    let to_mut_ptr = patterns.mk_local(u8_mut_ptr_ty).into_place();
-    let from_len = patterns.mk_local(usize_ty).into_place();
-    // FIXME: unnecessary pattern
-    let from_len_mut = patterns.mk_local(usize_ty).into_place();
-    let ty_size = patterns.mk_local(usize_ty).into_place();
-    // FIXME: unnecessary pattern
-    let ty_size_mut = patterns.mk_local(usize_ty).into_place();
-    let to_len = patterns.mk_local(usize_ty).into_place();
-    let to_len_mut = patterns.mk_local(usize_ty).into_place();
-    let to_raw_slice = patterns.mk_local(u8_slice_ptr_ty);
-    let to_mut_raw_slice = patterns.mk_local(u8_slice_mut_ptr_ty);
-    let to_slice = patterns.mk_local(u8_slice_ref_ty).into_place();
-    let to_mut_slice = patterns.mk_local(u8_slice_mut_ty).into_place();
-    let from_slice_deref = patterns.mk_place(from_slice, (tcx, &[pat::PlaceElem::Deref]));
-    let from_mut_slice_deref = patterns.mk_place(from_mut_slice, (tcx, &[pat::PlaceElem::Deref]));
-    let to_raw_slice_deref = patterns.mk_place(to_raw_slice, (tcx, &[pat::PlaceElem::Deref]));
-    let to_mut_raw_slice_deref = patterns.mk_place(to_mut_raw_slice, (tcx, &[pat::PlaceElem::Deref]));
+        let from_slice: &[T] = ...;
+        let from_slice_mut: &mut [T] = ...;
 
-    let cast_from = patterns.mk_init(from_slice);
-    let cast_from_mut = patterns.mk_init(from_mut_slice);
-    patterns.mk_assign(from_raw, pat::Rvalue::AddressOf(mir::Mutability::Not, from_slice_deref));
-    patterns.mk_assign(
-        from_raw_mut,
-        pat::Rvalue::AddressOf(mir::Mutability::Mut, from_mut_slice_deref),
-    );
-    patterns.mk_assign(
-        to_ptr,
-        pat::Rvalue::Cast(mir::CastKind::PtrToPtr, pat::Copy(from_raw), u8_ptr_ty),
-    );
-    patterns.mk_assign(
-        to_mut_ptr,
-        pat::Rvalue::Cast(mir::CastKind::PtrToPtr, pat::Copy(from_raw_mut), u8_mut_ptr_ty),
-    );
-    patterns.mk_assign(from_len, pat::Rvalue::Len(from_slice_deref));
-    // FIXME: unnecessary pattern
-    patterns.mk_assign(from_len_mut, pat::Rvalue::Len(from_mut_slice_deref));
-    patterns.mk_assign(ty_size, pat::Rvalue::NullaryOp(mir::NullOp::SizeOf, ty));
-    // FIXME: unnecessary pattern
-    patterns.mk_assign(ty_size_mut, pat::Rvalue::NullaryOp(mir::NullOp::SizeOf, ty));
-    patterns.mk_assign(
-        to_len,
-        pat::Rvalue::BinaryOp(mir::BinOp::Mul, Box::new([pat::Move(from_len), pat::Move(ty_size)])),
-    );
-    // FIXME: unnecessary pattern
-    patterns.mk_assign(
-        to_len_mut,
-        pat::Rvalue::BinaryOp(
-            mir::BinOp::Mul,
-            Box::new([pat::Move(from_len_mut), pat::Move(ty_size_mut)]),
-        ),
-    );
-    patterns.mk_assign(
-        to_raw_slice.into_place(),
-        pat::Rvalue::Aggregate(
-            pat::AggKind::RawPtr(u8_slice_ty, ty::Mutability::Not),
-            [pat::Copy(to_ptr), pat::Copy(to_len)].into_iter().collect(),
-        ),
-    );
-    patterns.mk_assign(
-        to_mut_raw_slice.into_place(),
-        pat::Rvalue::Aggregate(
-            pat::AggKind::RawPtr(u8_slice_ty, ty::Mutability::Mut),
-            [pat::Copy(to_mut_ptr), pat::Copy(to_len_mut)].into_iter().collect(),
-        ),
-    );
-    let cast_to = patterns.mk_assign(
-        to_slice,
-        pat::Rvalue::Ref(pat::RegionKind::ReErased, mir::BorrowKind::Shared, to_raw_slice_deref),
-    );
-    let cast_to_mut = patterns.mk_assign(
-        to_mut_slice,
-        pat::Rvalue::Ref(
-            pat::RegionKind::ReErased,
-            mir::BorrowKind::Mut {
-                kind: mir::MutBorrowKind::Default,
-            },
-            to_mut_raw_slice_deref,
-        ),
-    );
+        let from_raw: *const [T] = &raw const *from_slice;
+        let from_raw_mut: *mut [T] = &raw mut *from_slice_mut;
+
+        let from_len: usize = Len(*from_slice);
+        let from_len_mut: usize = Len(*from_slice_mut);
+
+        let ty_size: usize = SizeOf(T);
+        let ty_size_mut: usize = SizeOf(T);
+
+        let to_ptr: *const u8 = from_raw as *const u8 (PtrToPtr);
+        let to_ptr_mut: *mut u8 = from_raw_mut as *mut u8 (PtrToPtr);
+
+        let to_len: usize = Mul(move from_len, move ty_size);
+        let to_len_mut: usize = Mul(move from_len_mut, move ty_size_mut);
+
+        let to_raw: *const [u8] = *const [u8] from (to_ptr, to_len);
+        let to_raw_mut: *mut [u8] = *mut [u8] from (to_ptr_mut, to_len_mut);
+
+        let to_slice: &[u8] = &*to_raw;
+        let to_slice_mut: &mut [u8] = &mut *to_raw_mut;
+    }
+
     Pattern {
-        ty_var,
-        cast_from,
-        cast_from_mut,
-        cast_to,
-        cast_to_mut,
+        ty_var: T_ty_var,
+        cast_from: from_slice_stmt,
+        cast_from_mut: from_slice_mut_stmt,
+        cast_to: to_slice_stmt,
+        cast_to_mut: to_slice_mut_stmt,
     }
 }
 

--- a/crates/rpl_patterns/src/cve_2020_35873.rs
+++ b/crates/rpl_patterns/src/cve_2020_35873.rs
@@ -92,31 +92,28 @@ fn pattern<'tcx>(tcx: TyCtxt<'tcx>, patterns: &mut pat::Patterns<'tcx>) -> Patte
         &[],
     );
 
-    let u8_ty = patterns.mk_ty(tcx, pat::TyKind::Uint(ty::UintTy::U8));
-    let u8_slice_ty = patterns.mk_ty(tcx, pat::TyKind::Slice(u8_ty));
-    // let u8_slice_ref_ty = patterns.mk_ty(
-    //     tcx,
-    //     pat::TyKind::Ref(pat::RegionKind::ReErased, u8_slice_ty, ty::Mutability::Not),
+    let u8_ty = patterns.primitive_types.u8;
+    let u8_slice_ty = patterns.mk_slice_ty(tcx, u8_ty);
+    // let u8_slice_ref_ty = patterns.mk_ref_ty(
+    //     tcx, pat::RegionKind::ReErased, u8_slice_ty, ty::Mutability::Not,
     // );
-    let u8_slice_ptr_ty = patterns.mk_ty(tcx, pat::TyKind::RawPtr(u8_slice_ty, mir::Mutability::Not));
+    let u8_slice_ptr_ty = patterns.mk_raw_ptr_ty(tcx, u8_slice_ty, mir::Mutability::Not);
     let non_null_u8_slice_ty = patterns.mk_adt_ty(
         tcx,
         (tcx, &[sym::core, sym::ptr, Symbol::intern("non_null"), sym::NonNull]),
         (tcx, &[u8_slice_ty.into()]),
     );
 
-    let i32_ty = patterns.mk_ty(tcx, pat::TyKind::Int(ty::IntTy::I32));
+    let i32_ty = patterns.primitive_types.i32;
+    let i8_ty = patterns.primitive_types.i8;
+    let i8_ptr_ty = patterns.mk_raw_ptr_ty(tcx, i8_ty, mir::Mutability::Not);
+    let i8_slice_ty = patterns.mk_slice_ty(tcx, i8_ty);
+    let i8_slice_ptr_ty = patterns.mk_raw_ptr_ty(tcx, i8_slice_ty, mir::Mutability::Not);
 
-    let i8_ty = patterns.mk_ty(tcx, pat::TyKind::Int(ty::IntTy::I8));
-    let i8_ptr_ty = patterns.mk_ty(tcx, pat::TyKind::RawPtr(i8_ty, mir::Mutability::Not));
-    let i8_slice_ty = patterns.mk_ty(tcx, pat::TyKind::Slice(i8_ty));
-    let i8_slice_ptr_ty = patterns.mk_ty(tcx, pat::TyKind::RawPtr(i8_slice_ty, mir::Mutability::Not));
-
-    // let cstr_ref_ty = patterns.mk_ty(
-    //     tcx,
-    //     pat::TyKind::Ref(pat::RegionKind::ReErased, cstr_ty, mir::Mutability::Not),
+    // let cstr_ref_ty = patterns.mk_ref_ty(
+    //     tcx, pat::RegionKind::ReErased, cstr_ty, mir::Mutability::Not,
     // );
-    let cstr_ptr_ty = patterns.mk_ty(tcx, pat::TyKind::RawPtr(cstr_ty, mir::Mutability::Not));
+    let cstr_ptr_ty = patterns.mk_raw_ptr_ty(tcx, cstr_ty, mir::Mutability::Not);
 
     let cstring_local = patterns.mk_local(cstring_ty);
     let non_null_local = patterns.mk_local(non_null_u8_slice_ty);


### PR DESCRIPTION
TODO:

- [ ] Intern types and other stuff in MIR patterns (make sure multiple calls of `mk_ty` return the same address for the same type).
- [ ] Handle path types (`Adt`, `FnDef`, etc.).
- [ ] Infer types of locals (most types can be inferred from the Rvalue, such as `Cast`, `Aggregate`, `Ref`, `AddressOf`, etc.).
- [ ] Support exporting type, locals, and statements by names (i.e. `#[export = ident]`).