### PR TITLE
Add patterns for CVE-2019-15548 and support matching items by definition path.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,14 @@
 - Use `cargo uitest` (short for `cargo test --test compile-test`) to run compile tests.
 - Use `cargo uibless` (short for `cargo test --test compile-test --bless`) to run compile tests (in bless mode), which means the `.stderr` file will be automatically fixed according to the compiler outputs.
 
+## Test Directives
+
+You can control the way a test is built and interpreted through adding test directives.
+
+See <https://rustc-dev-guide.rust-lang.org/tests/directives.html> for more information.
+
+The currently mostly used one is `//@ ignore-on-host`.
+
 # Installation
 
 First, use `cargo install --path .` in current directory to install RPL as a cargo subcommand.

--- a/crates/rpl_context/src/context.rs
+++ b/crates/rpl_context/src/context.rs
@@ -79,6 +79,7 @@ impl<'pcx> PatternCtxt<'pcx> {
         Registry::new(NonZero::new(1).unwrap()).register();
         rustc_span::create_session_if_not_set_then(rustc_span::edition::LATEST_STABLE_EDITION, |_| Self::entered(f))
     }
+    /// Maps strings to their interned representation
     pub fn mk_symbols(&self, syms: &[&str]) -> &'pcx [Symbol] {
         self.arena.alloc_from_iter(syms.iter().copied().map(Symbol::intern))
     }

--- a/crates/rpl_context/src/pat/ty.rs
+++ b/crates/rpl_context/src/pat/ty.rs
@@ -77,6 +77,7 @@ pub struct ItemPath<'pcx>(pub &'pcx [Symbol]);
 
 #[derive(Clone, Copy)]
 pub enum Path<'pcx> {
+    /// Such as `std::vec::Vec`?
     Item(ItemPath<'pcx>),
     TypeRelative(Ty<'pcx>, Symbol),
     LangItem(LangItem),

--- a/crates/rpl_mir/src/lib.rs
+++ b/crates/rpl_mir/src/lib.rs
@@ -753,8 +753,8 @@ impl<'pcx, 'tcx> CheckMirCtxt<'_, 'pcx, 'tcx> {
     }
 
     /// Resolve definition path from `path`.
-    /// 
-    // FIXME: when searching in the same crate, an item path should always be resolved to the same item, so this can be cached for performance.
+    // FIXME: when searching in the same crate, an item path should always be resolved to the same item,
+    // so this can be cached for performance.
     fn match_item_path_by_def_path(&self, path: pat::ItemPath<'pcx>, def_id: DefId) -> bool {
         let res = resolve::def_path_res(self.tcx, path.0);
         let mut res = res.into_iter().filter_map(|res| match res {

--- a/crates/rpl_mir/src/lib.rs
+++ b/crates/rpl_mir/src/lib.rs
@@ -772,6 +772,7 @@ impl<'pcx, 'tcx> CheckMirCtxt<'_, 'pcx, 'tcx> {
 
     fn match_item_path(&self, path: pat::ItemPath<'pcx>, def_id: DefId) -> Option<&[Symbol]> {
         let &[krate, ref in_crate @ ..] = path.0 else {
+            // an empty `ItemPath`
             return None;
         };
         let def_path = self.tcx.def_path(def_id);
@@ -788,6 +789,7 @@ impl<'pcx, 'tcx> CheckMirCtxt<'_, 'pcx, 'tcx> {
         let matched = matched
             && std::iter::zip(pat_iter.by_ref(), iter.by_ref())
                 .all(|(&path, data)| data.data.get_opt_name().is_some_and(|name| name == path));
+        // Check that `iter` (from `def_path`) is not longer than `pat_iter` (from `path`)
         let matched = matched && iter.next().is_none();
         debug!(?path, ?def_id, matched, "match_item_path");
         matched.then_some(pat_iter.as_slice())

--- a/crates/rpl_mir/src/lib.rs
+++ b/crates/rpl_mir/src/lib.rs
@@ -39,6 +39,7 @@ use std::cell::RefCell;
 use std::iter::zip;
 
 use crate::graph::{MirControlFlowGraph, MirDataDepGraph, PatControlFlowGraph, PatDataDepGraph};
+use resolve::PatItemKind;
 use rpl_mir_graph::TerminatorEdges;
 use rustc_abi::VariantIdx;
 use rustc_hash::FxHashMap;
@@ -573,6 +574,7 @@ impl<'pcx, 'tcx> CheckMirCtxt<'_, 'pcx, 'tcx> {
 
     // FIXME
     #[allow(clippy::too_many_arguments)]
+    #[instrument(level = "trace", skip(self), ret)]
     fn match_agg_adt(
         &self,
         path_with_args: pat::PathWithArgs<'pcx>,
@@ -589,12 +591,16 @@ impl<'pcx, 'tcx> CheckMirCtxt<'_, 'pcx, 'tcx> {
         let path = path_with_args.path;
         let gargs_pat = path_with_args.args;
         let variant_matched = match path {
-            pattern::Path::Item(path) => match self.match_item_path(path, def_id) {
-                Some([]) => {
-                    variant_idx.as_u32() == 0 && matches!(adt.adt_kind(), ty::AdtKind::Struct | ty::AdtKind::Union)
-                },
-                Some(&[name]) => variant.name == name,
-                _ => false,
+            pattern::Path::Item(path) => {
+                self.match_item_path_by_def_path(path, def_id, PatItemKind::Ctor)
+                    || match self.match_item_path(path, def_id) {
+                        Some([]) => {
+                            variant_idx.as_u32() == 0
+                                && matches!(adt.adt_kind(), ty::AdtKind::Struct | ty::AdtKind::Union)
+                        },
+                        Some(&[name]) => variant.name == name,
+                        _ => false,
+                    }
             },
             pattern::Path::TypeRelative(_ty, _symbol) => false,
             pattern::Path::LangItem(lang_item) => self.tcx.is_lang_item(variant.def_id, lang_item),
@@ -725,6 +731,8 @@ impl<'pcx, 'tcx> CheckMirCtxt<'_, 'pcx, 'tcx> {
         matched
     }
 
+    /// Match type path
+    #[instrument(level = "trace", skip(self), ret)]
     fn match_path_with_args(
         &self,
         path_with_args: pat::PathWithArgs<'pcx>,
@@ -732,13 +740,15 @@ impl<'pcx, 'tcx> CheckMirCtxt<'_, 'pcx, 'tcx> {
         args: ty::GenericArgsRef<'tcx>,
     ) -> bool {
         let generics = self.tcx.generics_of(def_id);
-        self.match_path(path_with_args.path, def_id) && self.match_generic_args(path_with_args.args, args, generics)
+        self.match_path(path_with_args.path, def_id, PatItemKind::Fn)
+            && self.match_generic_args(path_with_args.args, args, generics)
     }
 
-    fn match_path(&self, path: pat::Path<'pcx>, def_id: DefId) -> bool {
+    #[instrument(level = "trace", skip(self), ret)]
+    fn match_path(&self, path: pat::Path<'pcx>, def_id: DefId, kind: PatItemKind) -> bool {
         let matched = match path {
             // pat::Path::Item(path) => matches!(self.match_item_path(path, def_id), Some([])),
-            pat::Path::Item(path) => self.match_item_path_by_def_path(path, def_id),
+            pat::Path::Item(path) => self.match_item_path_by_def_path(path, def_id, kind),
             pat::Path::TypeRelative(ty, name) => {
                 self.tcx.item_name(def_id) == name
                     && self
@@ -753,10 +763,12 @@ impl<'pcx, 'tcx> CheckMirCtxt<'_, 'pcx, 'tcx> {
     }
 
     /// Resolve definition path from `path`.
-    // FIXME: when searching in the same crate, an item path should always be resolved to the same item,
-    // so this can be cached for performance.
-    fn match_item_path_by_def_path(&self, path: pat::ItemPath<'pcx>, def_id: DefId) -> bool {
-        let res = resolve::def_path_res(self.tcx, path.0);
+    // FIXME: when searching in the same crate, if with the same kind, an item path should always be resolved to the
+    // same item, so this can be cached for performance.
+    #[instrument(level = "trace", skip(self), ret)]
+    fn match_item_path_by_def_path(&self, path: pat::ItemPath<'pcx>, def_id: DefId, kind: PatItemKind) -> bool {
+        let res = resolve::def_path_res(self.tcx, path.0, kind);
+        trace!(?res);
         let mut res = res.into_iter().filter_map(|res| match res {
             Res::Def(_, id) => Some(id),
             _ => None,
@@ -850,6 +862,7 @@ impl<'pcx, 'tcx> CheckMirCtxt<'_, 'pcx, 'tcx> {
         false
     }
 
+    #[instrument(level = "trace", skip(self), ret)]
     fn match_const_operand(&self, pat: &pat::ConstOperand<'pcx>, konst: mir::Const<'tcx>) -> bool {
         let matched = match (pat, konst) {
             (&pat::ConstOperand::ConstVar(const_var), mir::Const::Ty(_, konst)) => {
@@ -867,14 +880,14 @@ impl<'pcx, 'tcx> CheckMirCtxt<'_, 'pcx, 'tcx> {
                 })
             },
             (&pat::ConstOperand::ZeroSized(path_with_args), mir::Const::Val(mir::ConstValue::ZeroSized, ty)) => {
-                let (def_id, _args) = match *ty.kind() {
-                    ty::FnDef(def_id, args) => (def_id, args),
-                    ty::Adt(adt, args) => (adt.did(), args),
+                let (def_id, _args, kind) = match *ty.kind() {
+                    ty::FnDef(def_id, args) => (def_id, args, PatItemKind::Fn),
+                    ty::Adt(adt, args) => (adt.did(), args, PatItemKind::Type),
                     _ => return false,
                 };
                 // self.match_path_with_args(path_with_args, def_id, args)
                 // FIXME: match the arguments
-                self.match_path(path_with_args.path, def_id)
+                self.match_path(path_with_args.path, def_id, kind)
             },
             _ => false,
         };

--- a/crates/rpl_mir/src/resolve.rs
+++ b/crates/rpl_mir/src/resolve.rs
@@ -41,20 +41,25 @@ use rustc_span::Symbol;
 pub enum PatItemKind {
     // Type namespace
     /// [DefKind::Mod]
+    #[expect(dead_code)]
     Mod,
     /// [DefKind::Struct], [DefKind::Union], [DefKind::Enum], [DefKind::TyAlias],
     /// [DefKind::ForeignTy] and [DefKind::AssocTy]
     Type,
     /// [DefKind::Variant]
+    #[expect(dead_code)]
     Variant,
     /// [DefKind::Trait] and [DefKind::TraitAlias]
+    #[expect(dead_code)]
     Trait,
     /// [DefKind::Fn], [DefKind::AssocFn]
     Fn,
     /// [DefKind::Const], [DefKind::AssocConst]
+    #[expect(dead_code)]
     Const,
     /// [DefKind::Static]
     // FIXME: add fields to support more operations.
+    #[expect(dead_code)]
     Static,
     /// [DefKind::Ctor]
     Ctor,

--- a/crates/rpl_mir/src/resolve.rs
+++ b/crates/rpl_mir/src/resolve.rs
@@ -1,0 +1,210 @@
+//! Resolve an item path.
+//!
+//! See https://doc.rust-lang.org/nightly/nightly-rustc/src/clippy_utils/lib.rs.html#691
+use rustc_hir::def::{DefKind, Res};
+use rustc_hir::def_id::{CrateNum, LocalDefId, LOCAL_CRATE};
+use rustc_hir::{ImplItemRef, ItemKind, Node, OwnerId, PrimTy, TraitItemRef};
+use rustc_middle::ty::fast_reject::SimplifiedType;
+use rustc_middle::ty::{FloatTy, IntTy, Mutability, TyCtxt, UintTy};
+use rustc_span::def_id::DefId;
+use rustc_span::symbol::Ident;
+use rustc_span::Symbol;
+
+/// Resolves a def path like `std::vec::Vec`.
+///
+/// Can return multiple resolutions when there are multiple versions of the same crate, e.g.
+/// `memchr::memchr` could return the functions from both memchr 1.0 and memchr 2.0.
+///
+/// Also returns multiple results when there are multiple paths under the same name e.g. `std::vec`
+/// would have both a [`DefKind::Mod`] and [`DefKind::Macro`].
+///
+/// This function is expensive and should be used sparingly.
+#[instrument(level = "debug", skip(tcx), ret)]
+pub fn def_path_res(tcx: TyCtxt<'_>, path: &[Symbol]) -> Vec<Res> {
+    let (base, path) = match path {
+        [primitive] => {
+            return vec![PrimTy::from_name(*primitive).map_or(Res::Err, Res::PrimTy)];
+        },
+        [base, path @ ..] => (base, path),
+        [] => return Vec::new(),
+    };
+
+    // let base_sym = Symbol::intern(base);
+
+    let local_crate = if tcx.crate_name(LOCAL_CRATE) == *base || "crate" == base.as_str() {
+        Some(LOCAL_CRATE.as_def_id())
+    } else {
+        None
+    };
+
+    let crates = find_primitive_impls(tcx, *base)
+        .chain(local_crate)
+        .map(|id| Res::Def(tcx.def_kind(id), id))
+        .chain(find_crates(tcx, *base))
+        .collect();
+
+    trace!(?crates);
+
+    def_path_res_with_base(tcx, crates, path)
+}
+
+/// Resolves a def path like `vec::Vec` with the base `std`.
+///
+/// This is lighter than [`def_path_res`], and should be called with [`find_crates`] looking up
+/// items from the same crate repeatedly, although should still be used sparingly.
+#[instrument(level = "debug", skip(tcx), ret)]
+pub fn def_path_res_with_base(tcx: TyCtxt<'_>, mut base: Vec<Res>, mut path: &[Symbol]) -> Vec<Res> {
+    while let [segment, rest @ ..] = path {
+        path = rest;
+        // let segment = Symbol::intern(segment);
+        let segment = *segment;
+
+        base = base
+            .into_iter()
+            .filter_map(|res| res.opt_def_id())
+            .flat_map(|def_id| {
+                // When the current def_id is e.g. `struct S`, check the impl items in
+                // `impl S { ... }`
+                let inherent_impl_children = tcx
+                    .inherent_impls(def_id)
+                    .iter()
+                    .flat_map(|&impl_def_id| item_children_by_name(tcx, impl_def_id, segment));
+
+                let direct_children = item_children_by_name(tcx, def_id, segment);
+
+                inherent_impl_children.chain(direct_children)
+            })
+            .collect();
+
+        trace!(?segment, ?rest, ?base);
+    }
+
+    base
+}
+
+#[instrument(level = "trace", skip(tcx), ret)]
+fn non_local_item_children_by_name(tcx: TyCtxt<'_>, def_id: DefId, name: Symbol) -> Vec<Res> {
+    match tcx.def_kind(def_id) {
+        DefKind::Mod | DefKind::Enum | DefKind::Trait => tcx
+            .module_children(def_id)
+            .iter()
+            .filter(|item| item.ident.name == name)
+            .map(|child| child.res.expect_non_local())
+            .collect(),
+        DefKind::Impl { .. } => tcx
+            .associated_item_def_ids(def_id)
+            .iter()
+            .copied()
+            .filter(|assoc_def_id| tcx.item_name(*assoc_def_id) == name)
+            .map(|assoc_def_id| Res::Def(tcx.def_kind(assoc_def_id), assoc_def_id))
+            .collect(),
+        _ => Vec::new(),
+    }
+}
+
+#[instrument(level = "trace", skip(tcx), ret)]
+fn local_item_children_by_name(tcx: TyCtxt<'_>, local_id: LocalDefId, name: Symbol) -> Vec<Res> {
+    let hir = tcx.hir();
+
+    let root_mod;
+    let item_kind = match tcx.hir_node_by_def_id(local_id) {
+        Node::Crate(r#mod) => {
+            root_mod = ItemKind::Mod(r#mod);
+            &root_mod
+        },
+        Node::Item(item) => &item.kind,
+        _ => return Vec::new(),
+    };
+
+    trace!(?item_kind);
+
+    let res = |ident: Ident, owner_id: OwnerId| {
+        trace!(?ident, ?name, ?owner_id);
+        if ident.name == name {
+            let def_id = owner_id.to_def_id();
+            Some(Res::Def(tcx.def_kind(def_id), def_id))
+        } else {
+            None
+        }
+    };
+
+    match item_kind {
+        ItemKind::Mod(r#mod) => r#mod
+            .item_ids
+            .iter()
+            .filter_map(|&item_id| {
+                let item = hir.item(item_id);
+                match item.kind {
+                    ItemKind::ForeignMod { abi: _, items } => {
+                        items.iter().find_map(|item| res(item.ident, item.id.owner_id))
+                    },
+                    _ => res(item.ident, item_id.owner_id),
+                }
+            })
+            .collect(),
+        ItemKind::Impl(r#impl) => r#impl
+            .items
+            .iter()
+            .filter_map(|&ImplItemRef { ident, id, .. }| res(ident, id.owner_id))
+            .collect(),
+        ItemKind::Trait(.., trait_item_refs) => trait_item_refs
+            .iter()
+            .filter_map(|&TraitItemRef { ident, id, .. }| res(ident, id.owner_id))
+            .collect(),
+        _ => Vec::new(),
+    }
+}
+
+#[instrument(level = "debug", skip(tcx), ret)]
+fn item_children_by_name(tcx: TyCtxt<'_>, def_id: DefId, name: Symbol) -> Vec<Res> {
+    if let Some(local_id) = def_id.as_local() {
+        local_item_children_by_name(tcx, local_id, name)
+    } else {
+        non_local_item_children_by_name(tcx, def_id, name)
+    }
+}
+
+/// Finds the crates called `name`, may be multiple due to multiple major versions.
+pub fn find_crates(tcx: TyCtxt<'_>, name: Symbol) -> Vec<Res> {
+    tcx.crates(())
+        .iter()
+        .copied()
+        .filter(move |&num| tcx.crate_name(num) == name)
+        .map(CrateNum::as_def_id)
+        .map(|id| Res::Def(tcx.def_kind(id), id))
+        .collect()
+}
+
+fn find_primitive_impls(tcx: TyCtxt<'_>, name: Symbol) -> impl Iterator<Item = DefId> + '_ {
+    let ty = match name.as_str() {
+        "bool" => SimplifiedType::Bool,
+        "char" => SimplifiedType::Char,
+        "str" => SimplifiedType::Str,
+        "array" => SimplifiedType::Array,
+        "slice" => SimplifiedType::Slice,
+        // FIXME: rustdoc documents these two using just `pointer`.
+        //
+        // Maybe this is something we should do here too.
+        "const_ptr" => SimplifiedType::Ptr(Mutability::Not),
+        "mut_ptr" => SimplifiedType::Ptr(Mutability::Mut),
+        "isize" => SimplifiedType::Int(IntTy::Isize),
+        "i8" => SimplifiedType::Int(IntTy::I8),
+        "i16" => SimplifiedType::Int(IntTy::I16),
+        "i32" => SimplifiedType::Int(IntTy::I32),
+        "i64" => SimplifiedType::Int(IntTy::I64),
+        "i128" => SimplifiedType::Int(IntTy::I128),
+        "usize" => SimplifiedType::Uint(UintTy::Usize),
+        "u8" => SimplifiedType::Uint(UintTy::U8),
+        "u16" => SimplifiedType::Uint(UintTy::U16),
+        "u32" => SimplifiedType::Uint(UintTy::U32),
+        "u64" => SimplifiedType::Uint(UintTy::U64),
+        "u128" => SimplifiedType::Uint(UintTy::U128),
+        "f32" => SimplifiedType::Float(FloatTy::F32),
+        "f64" => SimplifiedType::Float(FloatTy::F64),
+        _ => {
+            return [].iter().copied();
+        },
+    };
+
+    tcx.incoherent_impls(ty).iter().copied()
+}

--- a/crates/rpl_patterns/messages.en.ftl
+++ b/crates/rpl_patterns/messages.en.ftl
@@ -17,3 +17,9 @@ rpl_patterns_wrong_assumption_of_fat_pointer_layout = wrong assumption of fat po
     .ptr_transmute_label = ptr transmute here 
     .get_data_ptr_label = try to get data ptr from first 8 bytes here
     .help = the Rust Compiler does not expose the layout of fat pointers
+
+rpl_patterns_rust_str_as_c_str = it is usually a but to cast a reference to `str` `&{$cast_from}` to a pointer to `libc::c_char` `&{$cast_to}`, and then pass it to a C function
+    .note = they may differ in terminator and encoding
+
+rpl_patterns_lengthless_buffer_passed_to_extern_function = it is usually a bug to pass a buffer pointer to an extern function without specifying its length
+    .label = the pointer is passed here

--- a/crates/rpl_patterns/src/cve_2019_15548.rs
+++ b/crates/rpl_patterns/src/cve_2019_15548.rs
@@ -1,0 +1,103 @@
+use std::ops::Not;
+
+use rpl_context::PatCtxt;
+use rpl_mir::pat::MirPatternBuilder;
+use rpl_mir::{pat, CheckMirCtxt};
+use rustc_hir as hir;
+use rustc_hir::def_id::LocalDefId;
+use rustc_hir::intravisit::{self, Visitor};
+use rustc_middle::hir::nested_filter::All;
+use rustc_middle::ty::TyCtxt;
+use rustc_span::Span;
+
+#[instrument(level = "info", skip(tcx, pcx))]
+pub fn check_item(tcx: TyCtxt<'_>, pcx: PatCtxt<'_>, item_id: hir::ItemId) {
+    let item = tcx.hir().item(item_id);
+    // let def_id = item_id.owner_id.def_id;
+    let mut check_ctxt = CheckFnCtxt { tcx, pcx };
+    check_ctxt.visit_item(item);
+}
+
+struct CheckFnCtxt<'pcx, 'tcx> {
+    tcx: TyCtxt<'tcx>,
+    pcx: PatCtxt<'pcx>,
+}
+
+impl<'tcx> Visitor<'tcx> for CheckFnCtxt<'_, 'tcx> {
+    type NestedFilter = All;
+    fn nested_visit_map(&mut self) -> Self::Map {
+        self.tcx.hir()
+    }
+
+    #[instrument(level = "debug", skip_all, fields(?item.owner_id))]
+    fn visit_item(&mut self, item: &'tcx hir::Item<'tcx>) -> Self::Result {
+        match item.kind {
+            hir::ItemKind::Trait(hir::IsAuto::No, hir::Safety::Safe, ..)
+            | hir::ItemKind::Impl(_)
+            | hir::ItemKind::Fn(..) => {},
+            _ => return,
+        }
+        intravisit::walk_item(self, item);
+    }
+
+    #[instrument(level = "info", skip_all, fields(?def_id))]
+    fn visit_fn(
+        &mut self,
+        kind: intravisit::FnKind<'tcx>,
+        decl: &'tcx hir::FnDecl<'tcx>,
+        body_id: hir::BodyId,
+        _span: Span,
+        def_id: LocalDefId,
+    ) -> Self::Result {
+        if self.tcx.visibility(def_id).is_public()
+            && kind.header().is_none_or(|header| header.is_unsafe().not())
+            && self.tcx.is_mir_available(def_id)
+        {
+            let body = self.tcx.optimized_mir(def_id);
+            #[allow(irrefutable_let_patterns)]
+            if let mut patterns_cast = MirPatternBuilder::new(self.pcx)
+                && let pattern_cast = pattern_rust_str_as_c_str(&mut patterns_cast)
+                && let Some(matches) = CheckMirCtxt::new(self.tcx, body, &patterns_cast.build()).check()
+                && let Some(cast_from) = matches[pattern_cast.cast_from]
+                && let cast_from = cast_from.span_no_inline(body)
+                && let Some(cast_to) = matches[pattern_cast.cast_to]
+                && let cast_to = cast_to.span_no_inline(body)
+            {
+                debug!(?cast_from, ?cast_to);
+                self.tcx
+                    .dcx()
+                    .emit_err(crate::errors::RustStrAsCStr { cast_from, cast_to });
+            }
+        }
+        intravisit::walk_fn(self, kind, decl, body_id, def_id);
+    }
+}
+
+struct PatternCast {
+    cast_from: pat::Location,
+    cast_to: pat::Location,
+}
+
+// FIXME: this does not work due to the lack of name resolution.
+// FIXME: this should work for `libc::char` but not hard encoded `i8`.
+// FIXME: this should work for functions other than `crate::ll::instr`.
+#[rpl_macros::mir_pattern]
+fn pattern_rust_str_as_c_str(patterns: &mut pat::MirPatternBuilder<'_>) -> PatternCast {
+    mir! {
+        meta!($T:ty);
+
+        // type c_char = libc::c_char;
+        type c_char = i8;
+
+        let src: &alloc::string::String = _;
+        let bytes: &[u8] = alloc::string::String::as_bytes(move src);
+        let ptr: *const u8 = core::slice::as_ptr(copy bytes);
+        let dst: *const c_char = copy ptr as *const c_char (Transmute);
+        let ret: $T = $crate::ll::instr(move dst);
+    }
+
+    PatternCast {
+        cast_from: src_stmt,
+        cast_to: dst_stmt,
+    }
+}

--- a/crates/rpl_patterns/src/cve_2019_15548_2.rs
+++ b/crates/rpl_patterns/src/cve_2019_15548_2.rs
@@ -65,7 +65,7 @@ impl<'tcx> Visitor<'tcx> for CheckFnCtxt<'_, 'tcx> {
             {
                 debug!(?ptr);
                 self.tcx.emit_node_span_lint(
-                    &LENGTHLESS_BUFFER_PASSED_TO_EXTERN_FUNCTION,
+                    LENGTHLESS_BUFFER_PASSED_TO_EXTERN_FUNCTION,
                     self.tcx.local_def_id_to_hir_id(def_id),
                     ptr,
                     crate::errors::LengthlessBufferPassedToExternFunction { ptr },

--- a/crates/rpl_patterns/src/cve_2019_15548_2.rs
+++ b/crates/rpl_patterns/src/cve_2019_15548_2.rs
@@ -1,0 +1,99 @@
+use std::ops::Not;
+
+use rpl_context::PatCtxt;
+use rpl_mir::pat::MirPatternBuilder;
+use rpl_mir::{pat, CheckMirCtxt};
+use rustc_hir as hir;
+use rustc_hir::def_id::LocalDefId;
+use rustc_hir::intravisit::{self, Visitor};
+use rustc_middle::hir::nested_filter::All;
+use rustc_middle::ty::TyCtxt;
+use rustc_span::Span;
+
+use crate::lints::LENGTHLESS_BUFFER_PASSED_TO_EXTERN_FUNCTION;
+
+#[instrument(level = "info", skip(tcx, pcx))]
+pub fn check_item(tcx: TyCtxt<'_>, pcx: PatCtxt<'_>, item_id: hir::ItemId) {
+    let item = tcx.hir().item(item_id);
+    // let def_id = item_id.owner_id.def_id;
+    let mut check_ctxt = CheckFnCtxt { tcx, pcx };
+    check_ctxt.visit_item(item);
+}
+
+struct CheckFnCtxt<'pcx, 'tcx> {
+    tcx: TyCtxt<'tcx>,
+    pcx: PatCtxt<'pcx>,
+}
+
+impl<'tcx> Visitor<'tcx> for CheckFnCtxt<'_, 'tcx> {
+    type NestedFilter = All;
+    fn nested_visit_map(&mut self) -> Self::Map {
+        self.tcx.hir()
+    }
+
+    #[instrument(level = "debug", skip_all, fields(?item.owner_id))]
+    fn visit_item(&mut self, item: &'tcx hir::Item<'tcx>) -> Self::Result {
+        match item.kind {
+            hir::ItemKind::Trait(hir::IsAuto::No, hir::Safety::Safe, ..)
+            | hir::ItemKind::Impl(_)
+            | hir::ItemKind::Fn(..) => {},
+            _ => return,
+        }
+        intravisit::walk_item(self, item);
+    }
+
+    #[instrument(level = "info", skip_all, fields(?def_id))]
+    fn visit_fn(
+        &mut self,
+        kind: intravisit::FnKind<'tcx>,
+        decl: &'tcx hir::FnDecl<'tcx>,
+        body_id: hir::BodyId,
+        _span: Span,
+        def_id: LocalDefId,
+    ) -> Self::Result {
+        if self.tcx.visibility(def_id).is_public()
+            && kind.header().is_none_or(|header| header.is_unsafe().not())
+            && self.tcx.is_mir_available(def_id)
+        {
+            let body = self.tcx.optimized_mir(def_id);
+            #[allow(irrefutable_let_patterns)]
+            if let mut patterns_ptr = MirPatternBuilder::new(self.pcx)
+                && let pattern_ptr = pattern_pass_a_pointer_to_c(&mut patterns_ptr)
+                && let Some(matches) = CheckMirCtxt::new(self.tcx, body, &patterns_ptr.build()).check()
+                && let Some(ptr) = matches[pattern_ptr.ptr]
+                && let ptr = ptr.span_no_inline(body)
+            {
+                debug!(?ptr);
+                self.tcx.emit_node_span_lint(
+                    &LENGTHLESS_BUFFER_PASSED_TO_EXTERN_FUNCTION,
+                    self.tcx.local_def_id_to_hir_id(def_id),
+                    ptr,
+                    crate::errors::LengthlessBufferPassedToExternFunction { ptr },
+                );
+            }
+        }
+        intravisit::walk_fn(self, kind, decl, body_id, def_id);
+    }
+}
+
+struct PatternPointer {
+    ptr: pat::Location,
+}
+
+// FIXME: this should work for `libc::char` but not hard encoded `i8`.
+// FIXME: this should work for functions other than `crate::ll::instr`.
+#[rpl_macros::mir_pattern]
+fn pattern_pass_a_pointer_to_c(patterns: &mut pat::MirPatternBuilder) -> PatternPointer {
+    mir! {
+        // type c_char = libc::c_char;
+        type c_char = i8;
+
+        let ptr: *const c_char = _;
+        _ = $crate::ll::instr(move ptr);
+    }
+
+    PatternPointer {
+        ptr: ptr_stmt,
+        // ty_var: c_char_ty,
+    }
+}

--- a/crates/rpl_patterns/src/errors.rs
+++ b/crates/rpl_patterns/src/errors.rs
@@ -1,5 +1,5 @@
 use rustc_errors::IntoDiagArg;
-use rustc_macros::Diagnostic;
+use rustc_macros::{Diagnostic, LintDiagnostic};
 use rustc_middle::ty::{self, Ty};
 use rustc_span::Span;
 
@@ -71,4 +71,22 @@ pub struct WrongAssumptionOfFatPointerLayout {
     pub ptr_transmute: Span,
     #[label(rpl_patterns_get_data_ptr_label)]
     pub data_ptr_get: Span,
+}
+
+// for cve_2019_15548
+#[derive(Diagnostic)]
+#[diag(rpl_patterns_rust_str_as_c_str)]
+pub struct RustStrAsCStr {
+    #[note]
+    pub cast_from: Span,
+    #[primary_span]
+    pub cast_to: Span,
+}
+
+// another pattern for cve_2019_15548
+#[derive(LintDiagnostic)]
+#[diag(rpl_patterns_lengthless_buffer_passed_to_extern_function)]
+pub struct LengthlessBufferPassedToExternFunction {
+    #[label(rpl_patterns_label)]
+    pub ptr: Span,
 }

--- a/crates/rpl_patterns/src/lib.rs
+++ b/crates/rpl_patterns/src/lib.rs
@@ -7,6 +7,7 @@ extern crate rustc_driver;
 extern crate rustc_errors;
 extern crate rustc_fluent_macro;
 extern crate rustc_hir;
+extern crate rustc_lint_defs;
 extern crate rustc_macros;
 extern crate rustc_middle;
 extern crate rustc_span;
@@ -22,16 +23,21 @@ use rustc_middle::ty::TyCtxt;
 pub(crate) mod errors;
 
 mod cve_2018_21000;
+mod cve_2019_15548;
+mod cve_2019_15548_2;
 mod cve_2020_25016;
 mod cve_2020_35881;
 mod cve_2020_35892_3;
 // mod cve_2020_35873;
+mod lints;
 
 rustc_fluent_macro::fluent_messages! { "../messages.en.ftl" }
 
 static ALL_PATTERNS: &[fn(TyCtxt<'_>, PatCtxt<'_>, ItemId)] = &[
     cve_2018_21000::t_to_u8::check_item,
     cve_2018_21000::u8_to_t::check_item,
+    cve_2019_15548::check_item,
+    cve_2019_15548_2::check_item,
     cve_2020_25016::check_item,
     cve_2020_35892_3::check_item,
     cve_2020_35881::const_const_Transmute_ver::check_item,

--- a/crates/rpl_patterns/src/lints.rs
+++ b/crates/rpl_patterns/src/lints.rs
@@ -6,17 +6,16 @@ declare_lint! {
     ///
     /// ### Example
     ///
-    /// ```rust,compile_fail
+    /// ```rust
     /// #![deny(lengthless_buffer_passed_to_extern_function)]
-    /// use libc::{c_char, c_int};
-    /// extern unsafe fn gets(c: *const c_char) -> c_int {
+    /// extern fn gets(c: *const i8) -> i32 {
     ///     0
     /// }
     ///
     /// fn main() {
-    ///     let mut p = [8; u8];
+    ///     let mut p = [8u8; 64];
     ///     unsafe {
-    ///         gets(p as *const c_char)
+    ///         gets(&p as *const u8 as *const i8);
     ///     }
     /// }
     /// ```

--- a/crates/rpl_patterns/src/lints.rs
+++ b/crates/rpl_patterns/src/lints.rs
@@ -27,7 +27,7 @@ declare_lint! {
     /// When you pass a lengthless buffer to an extern function, the most probable
     /// situation is that you are using some old style C API which fills the buffer
     /// as much as it has, and it's never safe to use.
-    /// 
+    ///
     /// However, in some cases, the size of the buffer may be fixed, and this lint
     /// can be suppressed then.
     pub LENGTHLESS_BUFFER_PASSED_TO_EXTERN_FUNCTION,

--- a/crates/rpl_patterns/src/lints.rs
+++ b/crates/rpl_patterns/src/lints.rs
@@ -1,0 +1,37 @@
+use rustc_lint_defs::declare_lint;
+
+declare_lint! {
+    /// The `lengthless_buffer_passed_to_extern_function` lint detects a buffer
+    /// pointer passed to an extern function without specifying its length.
+    ///
+    /// ### Example
+    ///
+    /// ```rust,compile_fail
+    /// #![deny(lengthless_buffer_passed_to_extern_function)]
+    /// use libc::{c_char, c_int};
+    /// extern unsafe fn gets(c: *const c_char) -> c_int {
+    ///     0
+    /// }
+    ///
+    /// fn main() {
+    ///     let mut p = [8; u8];
+    ///     unsafe {
+    ///         gets(p as *const c_char)
+    ///     }
+    /// }
+    /// ```
+    ///
+    /// {{produces}}
+    ///
+    /// ### Explanation
+    ///
+    /// When you pass a lengthless buffer to an extern function, the most probable
+    /// situation is that you are using some old style C API which fills the buffer
+    /// as much as it has, and it's never safe to use.
+    /// 
+    /// However, in some cases, the size of the buffer may be fixed, and this lint
+    /// can be suppressed then.
+    pub LENGTHLESS_BUFFER_PASSED_TO_EXTERN_FUNCTION,
+    Warn,
+    "detects a lengthless buffer passed to extern function"
+}

--- a/testing/src/main.rs
+++ b/testing/src/main.rs
@@ -1,5 +1,3 @@
-//@compile-flags: -lncurses
-//@compile-flags: -Z inline-mir=false
 
 use std::mem;
 
@@ -17,13 +15,12 @@ pub fn instr(s: &mut String) -> i32 {
     unsafe {
         let buf = s.as_bytes().as_ptr();
         let ret = ll::instr(mem::transmute(buf));
-        //~^ ERROR: it is usually a bug to pass a buffer pointer to an extern function without specifying its length
 
-        let capacity = s.capacity();
-        match s.find('\0') {
-            Some(index) => s.as_mut_vec().set_len(index as usize),
-            None => s.as_mut_vec().set_len(capacity),
-        }
+        // let capacity = s.capacity();
+        // match s.find('\0') {
+        //     Some(index) => s.as_mut_vec().set_len(index as usize),
+        //     None => s.as_mut_vec().set_len(capacity),
+        // }
 
         ret
     }

--- a/tests/ui/cve_2019_15548/cve_2019_15548.stderr
+++ b/tests/ui/cve_2019_15548/cve_2019_15548.stderr
@@ -1,0 +1,11 @@
+error: it is usually a bug to pass a buffer pointer to an extern function without specifying its length
+  --> tests/ui/cve_2019_15548/cve_2019_15548.rs:19:29
+   |
+LL |         let ret = ll::instr(mem::transmute(buf));
+   |                             ^^^^^^^^^^^^^^^^^^^ the function is called here
+   |
+   = note: `-D lengthless-buffer-passed-to-extern-function` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(lengthless_buffer_passed_to_extern_function)]`
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/cve_2019_15548/cve_2019_15548.stderr
+++ b/tests/ui/cve_2019_15548/cve_2019_15548.stderr
@@ -2,7 +2,7 @@ error: it is usually a bug to pass a buffer pointer to an extern function withou
   --> tests/ui/cve_2019_15548/cve_2019_15548.rs:19:29
    |
 LL |         let ret = ll::instr(mem::transmute(buf));
-   |                             ^^^^^^^^^^^^^^^^^^^ the function is called here
+   |                             ^^^^^^^^^^^^^^^^^^^ the pointer is passed here
    |
    = note: `-D lengthless-buffer-passed-to-extern-function` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(lengthless_buffer_passed_to_extern_function)]`


### PR DESCRIPTION
Add 2 patterns for CVE-2019-15548, and one pattern is by @stuuupidcat 's idea.

Add several functions for resolving an item path to the item's definition path, under the guide of @frank-king .