### PR TITLE
Lift `meta!(...)` in `mir! {}` to `#[meta(...)]` before items

### DIFF
--- a/crates/rpl_context/src/pat/item.rs
+++ b/crates/rpl_context/src/pat/item.rs
@@ -2,56 +2,59 @@ use rustc_data_structures::fx::FxHashMap;
 use rustc_middle::mir;
 use rustc_span::Symbol;
 
-use super::{MirPattern, Path, Ty};
+use super::{MetaVars, MirPattern, Path, Ty};
 
-pub struct AdtDef<'pcx> {
+pub struct Adt<'pcx> {
+    pub meta: MetaVars<'pcx>,
     kind: AdtKind<'pcx>,
 }
 
 pub enum AdtKind<'pcx> {
-    Struct(VariantDef<'pcx>),
-    Enum(FxHashMap<Symbol, VariantDef<'pcx>>),
+    Struct(Variant<'pcx>),
+    Enum(FxHashMap<Symbol, Variant<'pcx>>),
 }
 
 #[derive(Default)]
-pub struct VariantDef<'pcx> {
-    fields: FxHashMap<Symbol, FieldDef<'pcx>>,
+pub struct Variant<'pcx> {
+    fields: FxHashMap<Symbol, Field<'pcx>>,
 }
 
-pub struct FieldDef<'pcx> {
+pub struct Field<'pcx> {
     #[expect(dead_code)]
     ty: Ty<'pcx>,
 }
 
-pub struct ImplDef<'pcx> {
+pub struct Impl<'pcx> {
+    pub meta: MetaVars<'pcx>,
     #[expect(dead_code)]
     ty: Ty<'pcx>,
     #[expect(dead_code)]
     trait_id: Option<Path<'pcx>>,
     #[expect(dead_code)]
-    fns: FxHashMap<Symbol, FnDef<'pcx>>,
+    fns: FxHashMap<Symbol, Fn<'pcx>>,
 }
 
 #[derive(Default)]
-pub struct FnsDef<'pcx> {
-    fns: FxHashMap<Symbol, FnDef<'pcx>>,
-    fn_pats: FxHashMap<Symbol, FnDef<'pcx>>,
-    unnamed_fns: Vec<FnDef<'pcx>>,
+pub struct Fns<'pcx> {
+    fns: FxHashMap<Symbol, Fn<'pcx>>,
+    fn_pats: FxHashMap<Symbol, Fn<'pcx>>,
+    unnamed_fns: Vec<Fn<'pcx>>,
 }
 
-pub struct FnDef<'pcx> {
-    pub params: ParamsDef<'pcx>,
+pub struct Fn<'pcx> {
+    pub meta: MetaVars<'pcx>,
+    pub params: Params<'pcx>,
     pub ret: Ty<'pcx>,
     pub body: Option<FnBody<'pcx>>,
 }
 
 #[derive(Default)]
-pub struct ParamsDef<'pcx> {
-    params: Vec<ParamDef<'pcx>>,
+pub struct Params<'pcx> {
+    params: Vec<Param<'pcx>>,
     non_exhaustive: bool,
 }
 
-pub struct ParamDef<'pcx> {
+pub struct Param<'pcx> {
     pub mutability: mir::Mutability,
     pub ident: Symbol,
     pub ty: Ty<'pcx>,
@@ -64,30 +67,32 @@ pub enum FnBody<'pcx> {
     Mir(&'pcx MirPattern<'pcx>),
 }
 
-impl<'pcx> AdtDef<'pcx> {
+impl<'pcx> Adt<'pcx> {
     pub(crate) fn new_struct() -> Self {
         Self {
+            meta: MetaVars::default(),
             kind: AdtKind::Struct(Default::default()),
         }
     }
     pub(crate) fn new_enum() -> Self {
         Self {
+            meta: MetaVars::default(),
             kind: AdtKind::Enum(Default::default()),
         }
     }
-    pub(crate) fn non_enum_variant_mut(&mut self) -> &mut VariantDef<'pcx> {
+    pub(crate) fn non_enum_variant_mut(&mut self) -> &mut Variant<'pcx> {
         match &mut self.kind {
             AdtKind::Struct(variant) => variant,
             AdtKind::Enum(_) => panic!("cannot mutate non-enum variant of enum"),
         }
     }
-    pub fn add_variant(&mut self, name: Symbol) -> &mut VariantDef<'pcx> {
+    pub fn add_variant(&mut self, name: Symbol) -> &mut Variant<'pcx> {
         match &mut self.kind {
             AdtKind::Struct(_) => panic!("cannot add variant to struct"),
-            AdtKind::Enum(variants) => variants.entry(name).or_insert_with(VariantDef::default),
+            AdtKind::Enum(variants) => variants.entry(name).or_insert_with(Variant::default),
         }
     }
-    pub fn non_enum_variant(&self) -> &VariantDef<'pcx> {
+    pub fn non_enum_variant(&self) -> &Variant<'pcx> {
         match &self.kind {
             AdtKind::Struct(variant) => variant,
             AdtKind::Enum(_) => panic!("cannot access non-enum variant of enum"),
@@ -95,37 +100,33 @@ impl<'pcx> AdtDef<'pcx> {
     }
 }
 
-impl<'pcx> VariantDef<'pcx> {
+impl<'pcx> Variant<'pcx> {
     pub fn add_field(&mut self, name: Symbol, ty: Ty<'pcx>) {
-        self.fields.insert(name, FieldDef { ty });
+        self.fields.insert(name, Field { ty });
     }
 }
 
-impl<'pcx> FnsDef<'pcx> {
-    pub fn get_fn_pat(&self, name: Symbol) -> Option<&FnDef<'pcx>> {
+impl<'pcx> Fns<'pcx> {
+    pub fn get_fn_pat(&self, name: Symbol) -> Option<&Fn<'pcx>> {
         self.fn_pats.get(&name)
     }
-    // FIXME: remove this when all kinds of patterns are implemented
-    pub fn get_fn_pat_mir_body(&self, name: Symbol) -> Option<&MirPattern<'pcx>> {
-        let FnBody::Mir(mir_body) = self.fn_pats.get(&name)?.body?;
-        Some(mir_body)
+    pub fn new_fn(&mut self, name: Symbol, ret: Ty<'pcx>) -> &mut Fn<'pcx> {
+        self.fns.entry(name).or_insert_with(|| Fn::new(ret))
     }
-    pub fn new_fn(&mut self, name: Symbol, ret: Ty<'pcx>) -> &mut FnDef<'pcx> {
-        self.fns.entry(name).or_insert_with(|| FnDef::new(ret))
+    pub fn new_fn_pat(&mut self, name: Symbol, ret: Ty<'pcx>) -> &mut Fn<'pcx> {
+        self.fn_pats.entry(name).or_insert_with(|| Fn::new(ret))
     }
-    pub fn new_fn_pat(&mut self, name: Symbol, ret: Ty<'pcx>) -> &mut FnDef<'pcx> {
-        self.fn_pats.entry(name).or_insert_with(|| FnDef::new(ret))
-    }
-    pub fn new_unnamed(&mut self, ret: Ty<'pcx>) -> &mut FnDef<'pcx> {
-        self.unnamed_fns.push(FnDef::new(ret));
+    pub fn new_unnamed(&mut self, ret: Ty<'pcx>) -> &mut Fn<'pcx> {
+        self.unnamed_fns.push(Fn::new(ret));
         self.unnamed_fns.last_mut().unwrap()
     }
 }
 
-impl<'pcx> FnDef<'pcx> {
+impl<'pcx> Fn<'pcx> {
     pub(crate) fn new(ret: Ty<'pcx>) -> Self {
         Self {
-            params: ParamsDef::default(),
+            meta: MetaVars::default(),
+            params: Params::default(),
             ret,
             body: None,
         }
@@ -133,11 +134,18 @@ impl<'pcx> FnDef<'pcx> {
     pub fn set_body(&mut self, body: FnBody<'pcx>) {
         self.body = Some(body);
     }
+    // FIXME: remove this when all kinds of patterns are implemented
+    pub fn expect_mir_body(&self) -> &'pcx MirPattern<'pcx> {
+        match self.body {
+            Some(FnBody::Mir(mir_body)) => mir_body,
+            _ => panic!("expected MIR body"),
+        }
+    }
 }
 
-impl<'pcx> ParamsDef<'pcx> {
+impl<'pcx> Params<'pcx> {
     pub fn add_param(&mut self, ident: Symbol, mutability: mir::Mutability, ty: Ty<'pcx>) {
-        self.params.push(ParamDef { mutability, ident, ty });
+        self.params.push(Param { mutability, ident, ty });
     }
     pub fn set_non_exhaustive(&mut self) {
         self.non_exhaustive = true;

--- a/crates/rpl_context/src/pat/mir/pretty.rs
+++ b/crates/rpl_context/src/pat/mir/pretty.rs
@@ -216,7 +216,7 @@ impl fmt::Debug for ConstOperand<'_> {
     }
 }
 
-impl fmt::Debug for Field {
+impl fmt::Debug for FieldAcc {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::Named(sym) => write!(f, "{sym}"),
@@ -229,15 +229,6 @@ impl fmt::Debug for MirPattern<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let new_line = if f.alternate() { "\n" } else { " " };
         let indent = if f.alternate() { "    " } else { "" };
-        let mut meta = f.debug_tuple("meta!");
-        for ty_var in &self.ty_vars {
-            meta.field_with(|f| write!(f, "{ty_var:?}:ty"));
-        }
-        for const_var in &self.const_vars {
-            meta.field_with(|f| write!(f, "{const_var:?}"));
-        }
-        meta.finish()?;
-        write!(f, ";{new_line}")?;
         for (local, ty) in self.locals.iter_enumerated() {
             write!(f, "let {local:?}: {ty:?} ;{new_line}")?;
         }

--- a/crates/rpl_context/src/pat/mod.rs
+++ b/crates/rpl_context/src/pat/mod.rs
@@ -15,17 +15,16 @@ pub use ty::*;
 
 #[derive(Default)]
 pub struct MetaVars<'pcx> {
-    ty_vars: IndexVec<TyVarIdx, TyVar>,
-    const_vars: IndexVec<ConstVarIdx, ConstVar<'pcx>>,
+    pub ty_vars: IndexVec<TyVarIdx, TyVar>,
+    pub const_vars: IndexVec<ConstVarIdx, ConstVar<'pcx>>,
 }
 
 pub struct Pattern<'pcx> {
     pub pcx: PatCtxt<'pcx>,
-    pub meta: MetaVars<'pcx>,
-    adts: FxHashMap<Symbol, AdtDef<'pcx>>,
-    pub fns: FnsDef<'pcx>,
+    adts: FxHashMap<Symbol, Adt<'pcx>>,
+    pub fns: Fns<'pcx>,
     #[expect(dead_code)]
-    impls: Vec<ImplDef<'pcx>>,
+    impls: Vec<Impl<'pcx>>,
 }
 
 impl<'pcx> MetaVars<'pcx> {
@@ -47,19 +46,18 @@ impl<'pcx> Pattern<'pcx> {
     pub(crate) fn new(pcx: PatCtxt<'pcx>) -> Self {
         Self {
             pcx,
-            meta: MetaVars::default(),
             adts: Default::default(),
             fns: Default::default(),
             impls: Default::default(),
         }
     }
-    pub fn new_struct(&mut self, name: Symbol) -> &mut VariantDef<'pcx> {
+    pub fn new_struct(&mut self, name: Symbol) -> &mut Variant<'pcx> {
         self.adts
             .entry(name)
-            .or_insert_with(AdtDef::new_struct)
+            .or_insert_with(Adt::new_struct)
             .non_enum_variant_mut()
     }
-    pub fn new_enum(&mut self, name: Symbol) -> &mut AdtDef<'pcx> {
-        self.adts.entry(name).or_insert_with(AdtDef::new_enum)
+    pub fn new_enum(&mut self, name: Symbol) -> &mut Adt<'pcx> {
+        self.adts.entry(name).or_insert_with(Adt::new_enum)
     }
 }

--- a/crates/rpl_mir/src/matches/mod.rs
+++ b/crates/rpl_mir/src/matches/mod.rs
@@ -200,7 +200,7 @@ impl<'a, 'pcx, 'tcx> MatchCtxt<'a, 'pcx, 'tcx> {
                     num_blocks,
                 ),
                 locals: IndexVec::from_fn_n(|_| LocalMatches::new(num_locals), num_locals),
-                ty_vars: IndexVec::from_fn_n(|_| TyVarMatches::new(), cx.mir_pat.ty_vars.len()),
+                ty_vars: IndexVec::from_fn_n(|_| TyVarMatches::new(), cx.fn_pat.meta.ty_vars.len()),
             },
             // succeeded: Cell::new(false),
         }

--- a/crates/rpl_mir/tests/test_ddg.rs
+++ b/crates/rpl_mir/tests/test_ddg.rs
@@ -27,15 +27,20 @@ fn format_stmt_local((stmt, local): (usize, Local)) -> impl std::fmt::Debug {
 }
 
 macro_rules! test_case {
-    (fn $name:ident() {$($input:tt)*} => { $($deps:tt)* }) => {
+    (fn $name:ident() { meta!($($rpl_meta:tt)*); $($input:tt)* } => { $($deps:tt)* }) => {
         #[rpl_macros::pattern_def]
         fn $name(pcx: PatCtxt<'_>) -> &MirPattern<'_> {
             let pattern = rpl! {
+                #[meta($($rpl_meta)*)]
                 fn $pattern (..) -> _ = mir! {
                     $($input)*
                 }
             };
-            pattern.fns.get_fn_pat_mir_body(Symbol::intern("pattern")).unwrap()
+            pattern
+                .fns
+                .get_fn_pat(Symbol::intern("pattern"))
+                .unwrap()
+                .expect_mir_body()
         }
         #[test]
         fn ${concat(test_, $name)}() {

--- a/crates/rpl_pat_syntax/src/parse.rs
+++ b/crates/rpl_pat_syntax/src/parse.rs
@@ -634,17 +634,6 @@ impl Control {
     }
 }
 
-impl Parse for Meta {
-    fn parse(input: ParseStream<'_>) -> Result<Self> {
-        let meta: Macro<_, _, _> = input.parse()?;
-        let tk_semi = match meta.delim {
-            syn::MacroDelimiter::Paren(_) | syn::MacroDelimiter::Bracket(_) => Some(input.parse()?),
-            syn::MacroDelimiter::Brace(_) => input.parse()?,
-        };
-        Ok(Meta { meta, tk_semi })
-    }
-}
-
 #[macro_export]
 macro_rules! macro_delimiter {
     ($content:ident in $input:expr) => {{
@@ -703,7 +692,9 @@ impl<P: syn::parse::Parse + quote::ToTokens + token::Token, T: syn::parse::Parse
     }
 }
 
-impl<P: syn::parse::Parse + quote::ToTokens + token::Token, I: syn::parse::Parse + quote::ToTokens> Attribute<P, I> {
+impl<P: syn::parse::Parse + quote::ToTokens + token::Token, I: quote::ToTokens, Parse: ParseFn<I>>
+    Attribute<P, I, Parse>
+{
     pub fn parse_opt(input: ParseStream<'_>) -> Result<Option<Self>> {
         if let Some((punct, cursor)) = input.cursor().punct()
             && punct.as_char() == '#'

--- a/crates/rpl_patterns/src/cve_2018_20992.rs
+++ b/crates/rpl_patterns/src/cve_2018_20992.rs
@@ -1,6 +1,5 @@
 pub mod extend {
     use rpl_context::PatCtxt;
-    use rpl_mir::pat::MirPattern;
     use rustc_hir as hir;
     use rustc_hir::def_id::LocalDefId;
     use rustc_hir::intravisit::{self, Visitor};
@@ -50,7 +49,7 @@ pub mod extend {
                 let body = self.tcx.optimized_mir(def_id);
                 #[allow(irrefutable_let_patterns)]
                 if let pattern = pattern_vec_set_len_to_extend(self.pcx)
-                    && let Some(matches) = CheckMirCtxt::new(self.tcx, self.pcx, body, pattern.mir_pat).check()
+                    && let Some(matches) = CheckMirCtxt::new(self.tcx, self.pcx, body, pattern.fn_pat).check()
                     && let Some(set_len_use) = matches[pattern.set_len_use]
                     && let span1 = set_len_use.span_no_inline(body)
                 {
@@ -63,7 +62,7 @@ pub mod extend {
     }
 
     struct VecSetLenToExtend<'pcx> {
-        mir_pat: &'pcx MirPattern<'pcx>,
+        fn_pat: &'pcx pat::Fn<'pcx>,
         set_len_use: pat::Location,
     }
 
@@ -71,8 +70,8 @@ pub mod extend {
     fn pattern_vec_set_len_to_extend(pcx: PatCtxt<'_>) -> VecSetLenToExtend<'_> {
         let set_len_use;
         let pattern = rpl! {
+            #[meta($T:ty)]
             fn $pattern(..) -> _ = mir! {
-                meta!{$T:ty}
 
                 type VecT = alloc::vec::Vec::<$T>;
                 type VecTRef = &alloc::vec::Vec::<$T>;
@@ -130,15 +129,14 @@ pub mod extend {
             }
         }; */
 
-        let mir_pat = pattern.fns.get_fn_pat_mir_body(Symbol::intern("pattern")).unwrap();
+        let fn_pat = pattern.fns.get_fn_pat(Symbol::intern("pattern")).unwrap();
 
-        VecSetLenToExtend { mir_pat, set_len_use }
+        VecSetLenToExtend { fn_pat, set_len_use }
     }
 }
 
 pub mod truncate {
     use rpl_context::PatCtxt;
-    use rpl_mir::pat::MirPattern;
     use rustc_hir as hir;
     use rustc_hir::def_id::LocalDefId;
     use rustc_hir::intravisit::{self, Visitor};
@@ -188,7 +186,7 @@ pub mod truncate {
                 let body = self.tcx.optimized_mir(def_id);
                 #[allow(irrefutable_let_patterns)]
                 if let pattern = pattern_vec_set_len_to_extend(self.pcx)
-                    && let Some(matches) = CheckMirCtxt::new(self.tcx, self.pcx, body, pattern.mir_pat).check()
+                    && let Some(matches) = CheckMirCtxt::new(self.tcx, self.pcx, body, pattern.fn_pat).check()
                     && let Some(set_len_use) = matches[pattern.set_len_use]
                     && let span1 = set_len_use.span_no_inline(body)
                 {
@@ -201,7 +199,7 @@ pub mod truncate {
     }
 
     struct VecSetLenToTruncate<'pcx> {
-        mir_pat: &'pcx MirPattern<'pcx>,
+        fn_pat: &'pcx pat::Fn<'pcx>,
         set_len_use: pat::Location,
     }
 
@@ -209,8 +207,8 @@ pub mod truncate {
     fn pattern_vec_set_len_to_extend(pcx: PatCtxt<'_>) -> VecSetLenToTruncate<'_> {
         let set_len_use;
         let pattern = rpl! {
+            #[meta($T:ty)]
             fn $pattern(..) -> _ = mir! {
-                meta!{$T:ty}
 
                 type VecT = alloc::vec::Vec::<$T>;
                 type VecTRef = &alloc::vec::Vec::<$T>;
@@ -239,8 +237,8 @@ pub mod truncate {
             }
         };
 
-        let mir_pat = pattern.fns.get_fn_pat_mir_body(Symbol::intern("pattern")).unwrap();
+        let fn_pat = pattern.fns.get_fn_pat(Symbol::intern("pattern")).unwrap();
 
-        VecSetLenToTruncate { mir_pat, set_len_use }
+        VecSetLenToTruncate { fn_pat, set_len_use }
     }
 }

--- a/crates/rpl_patterns/src/cve_2019_15548_2.rs
+++ b/crates/rpl_patterns/src/cve_2019_15548_2.rs
@@ -1,7 +1,6 @@
 use std::ops::Not;
 
 use rpl_context::PatCtxt;
-use rpl_mir::pat::MirPattern;
 use rpl_mir::{pat, CheckMirCtxt};
 use rustc_hir as hir;
 use rustc_hir::def_id::LocalDefId;
@@ -58,7 +57,7 @@ impl<'tcx> Visitor<'tcx> for CheckFnCtxt<'_, 'tcx> {
             let body = self.tcx.optimized_mir(def_id);
             #[allow(irrefutable_let_patterns)]
             if let pattern_ptr = pattern_pass_a_pointer_to_c(self.pcx)
-                && let Some(matches) = CheckMirCtxt::new(self.tcx, self.pcx, body, pattern_ptr.mir_pat).check()
+                && let Some(matches) = CheckMirCtxt::new(self.tcx, self.pcx, body, pattern_ptr.fn_pat).check()
                 && let Some(ptr) = matches[pattern_ptr.ptr]
                 && let ptr = ptr.span_no_inline(body)
             {
@@ -76,7 +75,7 @@ impl<'tcx> Visitor<'tcx> for CheckFnCtxt<'_, 'tcx> {
 }
 
 struct PatternPointer<'pcx> {
-    mir_pat: &'pcx MirPattern<'pcx>,
+    fn_pat: &'pcx pat::Fn<'pcx>,
     ptr: pat::Location,
 }
 
@@ -93,10 +92,10 @@ fn pattern_pass_a_pointer_to_c(pcx: PatCtxt<'_>) -> PatternPointer<'_> {
             _ = $crate::ll::instr(move ptr);
         }
     };
-    let mir_pat = pattern.fns.get_fn_pat_mir_body(Symbol::intern("pattern")).unwrap();
+    let fn_pat = pattern.fns.get_fn_pat(Symbol::intern("pattern")).unwrap();
 
     PatternPointer {
-        mir_pat,
+        fn_pat,
         ptr,
         // ty_var: c_char_ty,
     }

--- a/crates/rpl_patterns/src/cve_2020_35881.rs
+++ b/crates/rpl_patterns/src/cve_2020_35881.rs
@@ -1,7 +1,6 @@
 #[allow(non_snake_case)]
 pub mod const_const_Transmute_ver {
     use rpl_context::PatCtxt;
-    use rpl_mir::pat::MirPattern;
     use rustc_hir as hir;
     use rustc_hir::def_id::LocalDefId;
     use rustc_hir::intravisit::{self, Visitor};
@@ -51,7 +50,7 @@ pub mod const_const_Transmute_ver {
                 let body = self.tcx.optimized_mir(def_id);
                 #[allow(irrefutable_let_patterns)]
                 if let pattern = pattern_wrong_assumption_of_fat_pointer_layout(self.pcx)
-                    && let Some(matches) = CheckMirCtxt::new(self.tcx, self.pcx, body, pattern.mir_pat).check()
+                    && let Some(matches) = CheckMirCtxt::new(self.tcx, self.pcx, body, pattern.fn_pat).check()
                     && let Some(ptr_transmute) = matches[pattern.ptr_transmute]
                     && let span1 = ptr_transmute.span_no_inline(body)
                     && let Some(data_ptr_get) = matches[pattern.data_ptr_get]
@@ -69,7 +68,7 @@ pub mod const_const_Transmute_ver {
     }
 
     struct WrongAssumptionOfFatPointerLayout<'pcx> {
-        mir_pat: &'pcx MirPattern<'pcx>,
+        fn_pat: &'pcx pat::Fn<'pcx>,
         ptr_transmute: pat::Location,
         data_ptr_get: pat::Location,
     }
@@ -79,8 +78,8 @@ pub mod const_const_Transmute_ver {
         let ptr_transmute;
         let data_ptr_get;
         let pattern = rpl! {
+            #[meta($T:ty)]
             fn $pattern(..) -> _ = mir! {
-                meta!{$T:ty}
 
                 let ptr: *const $T = _;
                 // _4 = &_1;
@@ -95,10 +94,10 @@ pub mod const_const_Transmute_ver {
                 let data_ptr: *const () = _;
             }
         };
-        let mir_pat = pattern.fns.get_fn_pat_mir_body(Symbol::intern("pattern")).unwrap();
+        let fn_pat = pattern.fns.get_fn_pat(Symbol::intern("pattern")).unwrap();
 
         WrongAssumptionOfFatPointerLayout {
-            mir_pat,
+            fn_pat,
             ptr_transmute,
             data_ptr_get,
         }
@@ -108,7 +107,6 @@ pub mod const_const_Transmute_ver {
 #[allow(non_snake_case)]
 pub mod mut_mut_Transmute_ver {
     use rpl_context::PatCtxt;
-    use rpl_mir::pat::MirPattern;
     use rustc_hir as hir;
     use rustc_hir::def_id::LocalDefId;
     use rustc_hir::intravisit::{self, Visitor};
@@ -158,7 +156,7 @@ pub mod mut_mut_Transmute_ver {
                 let body = self.tcx.optimized_mir(def_id);
                 #[allow(irrefutable_let_patterns)]
                 if let pattern = pattern_wrong_assumption_of_fat_pointer_layout(self.pcx)
-                    && let Some(matches) = CheckMirCtxt::new(self.tcx, self.pcx, body, pattern.mir_pat).check()
+                    && let Some(matches) = CheckMirCtxt::new(self.tcx, self.pcx, body, pattern.fn_pat).check()
                     && let Some(ptr_transmute) = matches[pattern.ptr_transmute]
                     && let span1 = ptr_transmute.span_no_inline(body)
                     && let Some(data_ptr_get) = matches[pattern.data_ptr_get]
@@ -176,7 +174,7 @@ pub mod mut_mut_Transmute_ver {
     }
 
     struct WrongAssumptionOfFatPointerLayout<'pcx> {
-        mir_pat: &'pcx MirPattern<'pcx>,
+        fn_pat: &'pcx pat::Fn<'pcx>,
         ptr_transmute: pat::Location,
         data_ptr_get: pat::Location,
     }
@@ -186,8 +184,8 @@ pub mod mut_mut_Transmute_ver {
         let ptr_transmute;
         let data_ptr_get;
         let pattern = rpl! {
+            #[meta($T:ty)]
             fn $pattern (..) -> _ = mir! {
-                meta!{$T:ty}
 
                 let ptr: *mut $T = _;
                 // _4 = &mut _1;
@@ -203,10 +201,10 @@ pub mod mut_mut_Transmute_ver {
 
             }
         };
-        let mir_pat = pattern.fns.get_fn_pat_mir_body(Symbol::intern("pattern")).unwrap();
+        let fn_pat = pattern.fns.get_fn_pat(Symbol::intern("pattern")).unwrap();
 
         WrongAssumptionOfFatPointerLayout {
-            mir_pat,
+            fn_pat,
             ptr_transmute,
             data_ptr_get,
         }
@@ -216,7 +214,6 @@ pub mod mut_mut_Transmute_ver {
 #[allow(non_snake_case)]
 pub mod mut_const_PtrToPtr_ver {
     use rpl_context::PatCtxt;
-    use rpl_mir::pat::MirPattern;
     use rustc_hir as hir;
     use rustc_hir::def_id::LocalDefId;
     use rustc_hir::intravisit::{self, Visitor};
@@ -266,7 +263,7 @@ pub mod mut_const_PtrToPtr_ver {
                 let body = self.tcx.optimized_mir(def_id);
                 #[allow(irrefutable_let_patterns)]
                 if let pattern = pattern_wrong_assumption_of_fat_pointer_layout(self.pcx)
-                    && let Some(matches) = CheckMirCtxt::new(self.tcx, self.pcx, body, pattern.mir_pat).check()
+                    && let Some(matches) = CheckMirCtxt::new(self.tcx, self.pcx, body, pattern.fn_pat).check()
                     && let Some(ptr_transmute) = matches[pattern.ptr_transmute]
                     && let span1 = ptr_transmute.span_no_inline(body)
                     && let Some(data_ptr_get) = matches[pattern.data_ptr_get]
@@ -284,7 +281,7 @@ pub mod mut_const_PtrToPtr_ver {
     }
 
     struct WrongAssumptionOfFatPointerLayout<'pcx> {
-        mir_pat: &'pcx MirPattern<'pcx>,
+        fn_pat: &'pcx pat::Fn<'pcx>,
         ptr_transmute: pat::Location,
         data_ptr_get: pat::Location,
     }
@@ -293,9 +290,9 @@ pub mod mut_const_PtrToPtr_ver {
     fn pattern_wrong_assumption_of_fat_pointer_layout(pcx: PatCtxt<'_>) -> WrongAssumptionOfFatPointerLayout<'_> {
         let ptr_transmute;
         let data_ptr_get;
-        let mir_pat = rpl! {
+        let pattern = rpl! {
+            #[meta($T:ty)]
             fn $pattern (..) -> _ = mir! {
-                meta!{$T:ty}
 
                 let ptr: *const $T = _;
                 let ref_to_ptr: &mut *const $T = &mut ptr;
@@ -307,10 +304,10 @@ pub mod mut_const_PtrToPtr_ver {
                 let data_ptr: *mut () = _;
             }
         };
-        let mir_pat = mir_pat.fns.get_fn_pat_mir_body(Symbol::intern("pattern")).unwrap();
+        let fn_pat = pattern.fns.get_fn_pat(Symbol::intern("pattern")).unwrap();
 
         WrongAssumptionOfFatPointerLayout {
-            mir_pat,
+            fn_pat,
             ptr_transmute,
             data_ptr_get,
         }

--- a/crates/rpl_patterns/src/cve_2021_27376.rs
+++ b/crates/rpl_patterns/src/cve_2021_27376.rs
@@ -1,5 +1,4 @@
 use rpl_context::PatCtxt;
-use rpl_mir::pat::MirPattern;
 use rpl_mir::{pat, CheckMirCtxt};
 use rustc_hir as hir;
 use rustc_hir::def_id::LocalDefId;
@@ -51,7 +50,7 @@ impl<'tcx> Visitor<'tcx> for CheckFnCtxt<'_, 'tcx> {
             let body = self.tcx.optimized_mir(def_id);
             #[allow(irrefutable_let_patterns)]
             if let pattern_cast = pattern_cast_socket_addr_v6(self.pcx)
-                && let Some(matches) = CheckMirCtxt::new(self.tcx, self.pcx, body, pattern_cast.mir_pat).check()
+                && let Some(matches) = CheckMirCtxt::new(self.tcx, self.pcx, body, pattern_cast.fn_pat).check()
                 && let Some(cast_from) = matches[pattern_cast.cast_from]
                 && let cast_from = cast_from.span_no_inline(body)
                 && let Some(cast_to) = matches[pattern_cast.cast_to]
@@ -69,7 +68,7 @@ impl<'tcx> Visitor<'tcx> for CheckFnCtxt<'_, 'tcx> {
             }
             #[allow(irrefutable_let_patterns)]
             if let pattern_cast = pattern_cast_socket_addr_v4(self.pcx)
-                && let Some(matches) = CheckMirCtxt::new(self.tcx, self.pcx, body, pattern_cast.mir_pat).check()
+                && let Some(matches) = CheckMirCtxt::new(self.tcx, self.pcx, body, pattern_cast.fn_pat).check()
                 && let Some(cast_from) = matches[pattern_cast.cast_from]
                 && let cast_from = cast_from.span_no_inline(body)
                 && let Some(cast_to) = matches[pattern_cast.cast_to]
@@ -91,7 +90,7 @@ impl<'tcx> Visitor<'tcx> for CheckFnCtxt<'_, 'tcx> {
 }
 
 struct PatternCast<'pcx> {
-    mir_pat: &'pcx MirPattern<'pcx>,
+    fn_pat: &'pcx pat::Fn<'pcx>,
     cast_from: pat::Location,
     cast_to: pat::Location,
     type_from: &'static str,
@@ -110,10 +109,10 @@ fn pattern_cast_socket_addr_v6(pcx: PatCtxt<'_>) -> PatternCast<'_> {
             let dst: *const libc::sockaddr = move src as *const libc::sockaddr (PtrToPtr);
         }
     };
-    let mir_pat = pattern.fns.get_fn_pat_mir_body(Symbol::intern("pattern")).unwrap();
+    let fn_pat = pattern.fns.get_fn_pat(Symbol::intern("pattern")).unwrap();
 
     PatternCast {
-        mir_pat,
+        fn_pat,
         cast_from,
         cast_to,
         type_from: "std::net::SocketAddrV6",
@@ -133,10 +132,10 @@ fn pattern_cast_socket_addr_v4(pcx: PatCtxt<'_>) -> PatternCast<'_> {
             let dst: *const libc::sockaddr = move src as *const libc::sockaddr (PtrToPtr);
         }
     };
-    let mir_pat = pattern.fns.get_fn_pat_mir_body(Symbol::intern("pattern")).unwrap();
+    let fn_pat = pattern.fns.get_fn_pat(Symbol::intern("pattern")).unwrap();
 
     PatternCast {
-        mir_pat,
+        fn_pat,
         cast_from,
         cast_to,
         type_from: "std::net::SocketAddrV4",


### PR DESCRIPTION
Minor changes on declaring meta variables. CC @stuuupidcat @TheVeryDarkness.

Before this PR:
```rust
// There is no way to declare the meta variable `$T` in this subpattern.
struct $SlabT {
    mem: *mut $T,
    len: usize,
}

fn $pattern(..) -> _ = mir! {
    meta!($T:ty);
    ...
}
```

After this PR:
```rust
// Now we can declare the meta variable `$T` similarly in different subpatterns.
#[meta($T:ty)]
struct $SlabT {
    mem: *mut $T,
    len: usize,
}

// Note that this `$T` can match different type with that in subpattern `struct $SlabT`,
// so we have to declare them separately.
#[meta($T:ty)]
fn $pattern(..) -> _ = mir! {
    ...
}
```