### PR TITLE
 Fix pattern CVE-2020-35873 to make it detectible 

### DIFF
--- a/crates/rpl_pat_expand/src/tests.rs
+++ b/crates/rpl_pat_expand/src/tests.rs
@@ -2010,6 +2010,38 @@ fn test_cve_2020_35873() {
             );
         }
     }
+    test_case! {
+        pat! {
+            #[meta($SessT:ty)]
+            fn $ffi_call(*mut $SessT, *const std::ffi::c_char) -> i32;
+        } => quote! {
+            let ffi_call_fn = pattern.fns.new_fn_pat(::rustc_span::Symbol::intern("ffi_call"), pcx.primitive_types.i32);
+            #[allow(non_snake_case)]
+            let SessT_ty_var = ffi_call_fn.meta.new_ty_var(None);
+            #[allow(non_snake_case)]
+            let SessT_ty = pcx.mk_var_ty(SessT_ty_var );
+
+            ffi_call_fn.params.add_param(
+                ::rustc_span::symbol::kw::Empty,
+                ::rustc_middle::mir::Mutability::Not,
+                pcx.mk_raw_ptr_ty(
+                    SessT_ty,
+                    ::rustc_middle::mir::Mutability::Mut
+                )
+            );
+            ffi_call_fn.params.add_param(
+                ::rustc_span::symbol::kw::Empty,
+                ::rustc_middle::mir::Mutability::Not,
+                pcx.mk_raw_ptr_ty(
+                    pcx.mk_path_ty(pcx.mk_path_with_args(
+                        pcx.mk_item_path(&["std", "ffi", "c_char",]),
+                        &[]
+                    )),
+                    ::rustc_middle::mir::Mutability::Not
+                )
+            );
+        }
+    }
 }
 
 #[test]

--- a/crates/rpl_pat_syntax/src/tests.rs
+++ b/crates/rpl_pat_syntax/src/tests.rs
@@ -362,6 +362,10 @@ fn test_fn_pattern() {
     pass!(FnPat! {
         fn $pattern(i32, *const std::ffi::CStr) -> i32;
     });
+    pass!(Item! {
+        #[meta($SessT:ty)]
+        fn $ffi_call(*mut $SessT, *const std::ffi::c_char) -> i32;
+    });
 }
 
 #[test]

--- a/tests/ui/cve_2020_35873/cve_2020_35873.rs
+++ b/tests/ui/cve_2020_35873/cve_2020_35873.rs
@@ -1,5 +1,5 @@
 struct Session<'a> {
-    s: i32,
+    sess: *mut ffi::Session,
     _f: &'a (),
 }
 
@@ -26,14 +26,15 @@ impl Session<'_> {
             //~^ NOTE: the `std::ffi::CString` value is dropped here
             std::ptr::null()
         };
-        unsafe { check!(ffi::sqlite3session_attach(self.s, table)) };
+        unsafe { check!(ffi::sqlite3session_attach(self.sess, table)) };
         //~^ ERROR: use a pointer from `std::ffi::CString` after dropped
         Ok(())
     }
 }
 
 mod ffi {
+    pub type Session = std::ffi::c_void;
     extern "C" {
-        pub fn sqlite3session_attach(s: i32, table: *const std::ffi::c_char) -> i32;
+        pub fn sqlite3session_attach(s: *mut Session, table: *const std::ffi::c_char) -> i32;
     }
 }

--- a/tests/ui/cve_2020_35873/cve_2020_35873.stderr
+++ b/tests/ui/cve_2020_35873/cve_2020_35873.stderr
@@ -1,8 +1,8 @@
 error: use a pointer from `std::ffi::CString` after dropped
   --> tests/ui/cve_2020_35873/cve_2020_35873.rs:29:25
    |
-LL |         unsafe { check!(ffi::sqlite3session_attach(self.s, table)) };
-   |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |         unsafe { check!(ffi::sqlite3session_attach(self.sess, table)) };
+   |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: the `std::ffi::CString` value is dropped here
   --> tests/ui/cve_2020_35873/cve_2020_35873.rs:25:9


### PR DESCRIPTION
Now CVE-2020-35873 is detectible in the original crate (`rusquite < 0.23.0`) via the following commands
```
git clone https://github.com/rusqlite/rusqlite.git && cd rusqlite
git checkout 0.22.0
cargo +nightly-2024-10-23 rpl -F libsqlite3-sys/buildtime_bindgen -F session
```
![f3cbb236188e289d592f759701eeec5](https://github.com/user-attachments/assets/bfb47af5-c1bf-4d59-976c-4bef548b9838)
