### PR TITLE
Fix MIR matching algorithm

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,6 +61,19 @@ I haven't found a good solution but here is the hacks:
 -   Run `source ~/.bashrc` (or `source ~/.zshrc` if you use ZSH);
 -   Now return to the RPL repository and you may succeed to run `RPL_LOG=debug cargo +nightly-stage1 run -b rpl-driver` and you will see the debugging logs printed on the screen;
 
+### View logs
+
+The rustc logs are scope trees with indentations, it is helpful if your code editor support folding by indentations.
+
+In Vim, you can set fold method to `indent` and use `za` to toggle the folds on and off.
+```vim
+set shiftwidth=2
+set foldenable
+set foldmethod=indent
+```
+
+In VsCode, folding by indentation is supported by default.
+
 ## Debugging with VSCode and lldb
 
 When use the debug mode in VSCode, you may encounter the following error:

--- a/crates/rpl_context/src/pat/mir/mod.rs
+++ b/crates/rpl_context/src/pat/mir/mod.rs
@@ -57,6 +57,9 @@ pub struct BasicBlockData<'pcx> {
 }
 
 impl<'pcx> BasicBlockData<'pcx> {
+    pub fn has_pat_end(&self) -> bool {
+        matches!(self.terminator(), TerminatorKind::PatEnd)
+    }
     pub fn terminator(&self) -> &TerminatorKind<'pcx> {
         self.terminator.as_ref().expect("terminator not set")
     }

--- a/crates/rpl_match/src/lib.rs
+++ b/crates/rpl_match/src/lib.rs
@@ -58,8 +58,8 @@ impl<T: Copy + PartialEq> CountedMatch<T> {
     pub fn unmatch(&self) {
         self.0.update(|m| m.and_then(Counted::dec));
     }
-    pub fn try_take(self) -> Option<T> {
-        self.0.take().map(Counted::into_inner)
+    pub fn try_take(&self) -> Option<T> {
+        self.0.get().map(Counted::into_inner)
     }
 }
 

--- a/crates/rpl_mir_graph/src/graph.rs
+++ b/crates/rpl_mir_graph/src/graph.rs
@@ -563,10 +563,17 @@ impl<Local: Idx> BlockDataDepGraph<Local> {
     pub fn get_rdep_start(&self, statement: usize) -> impl Iterator<Item = Local> + '_ {
         self.rdep_start.get(&statement).into_iter().flat_map(HybridBitSet::iter)
     }
+    #[instrument(level = "debug", skip(self))]
+    pub fn is_rdep_start(&self, statement: usize, local: Local) -> bool {
+        self.rdep_start
+            .get(&statement)
+            .is_some_and(|locals| locals.contains(local))
+    }
     #[instrument(level = "debug", skip(self), ret)]
     pub fn get_dep_end(&self, statement: usize) -> Option<Local> {
         self.dep_end.get(&statement).copied()
     }
+    #[instrument(level = "debug", skip(self))]
     pub fn rdep_start(&self) -> impl Iterator<Item = (usize, Local)> + '_ {
         self.rdep_start
             .iter()
@@ -577,6 +584,9 @@ impl<Local: Idx> BlockDataDepGraph<Local> {
     }
     pub fn rdep_start_end(&self) -> impl Iterator<Item = Local> + '_ {
         self.rdep_start_end.iter()
+    }
+    pub fn is_rdep_start_end(&self, local: Local) -> bool {
+        self.rdep_start_end.contains(local)
     }
     pub fn full_rdep_start_end(&self) -> bool {
         (0..self.rw_states.num_locals())

--- a/crates/rpl_patterns/messages.en.ftl
+++ b/crates/rpl_patterns/messages.en.ftl
@@ -31,6 +31,7 @@ rpl_patterns_wrong_assumption_of_layout_compatibility = wrong assumption of layo
     .help  = it's not guaranteed by Rust standard library. See https://github.com/rust-lang/rust/pull/78802
 
 rpl_patterns_vec_set_len_to_extend = Use `Vec::set_len` to extend the length of a `Vec`, potentially including uninitialized elements
+    .label = `Vec` created here
     .note = make sure all elements are initialized before using them
 
 rpl_patterns_vec_set_len_to_truncate = Use `Vec::set_len` to truncate the length of a `Vec`

--- a/crates/rpl_patterns/src/cve_2018_21000.rs
+++ b/crates/rpl_patterns/src/cve_2018_21000.rs
@@ -46,20 +46,9 @@ pub mod u8_to_t {
         ) -> Self::Result {
             if self.tcx.visibility(def_id).is_public() && self.tcx.is_mir_available(def_id) {
                 let body = self.tcx.optimized_mir(def_id);
-                #[allow(irrefutable_let_patterns)]
-                if let pattern_misordered_params = pattern_misordered_params(self.pcx)
-                    && let Some(matches) = CheckMirCtxt::new(
-                        self.tcx,
-                        self.pcx,
-                        body,
-                        pattern_misordered_params.pattern,
-                        pattern_misordered_params.fn_pat,
-                    )
-                    .check()
-                    && let Some(matches) = matches.first()
-                    && let Some(from_raw_parts) = matches[pattern_misordered_params.from_raw_parts]
-                    && let span = from_raw_parts.span_no_inline(body)
-                {
+                let pattern = pattern_misordered_params(self.pcx);
+                for matches in CheckMirCtxt::new(self.tcx, self.pcx, body, pattern.pattern, pattern.fn_pat).check() {
+                    let span = matches[pattern.from_raw_parts].span_no_inline(body);
                     debug!(?span);
                     self.tcx.dcx().emit_err(crate::errors::MisorderedParameters { span });
                 }
@@ -231,20 +220,9 @@ pub mod t_to_u8 {
         ) -> Self::Result {
             if self.tcx.visibility(def_id).is_public() && self.tcx.is_mir_available(def_id) {
                 let body = self.tcx.optimized_mir(def_id);
-                #[allow(irrefutable_let_patterns)]
-                if let pattern_misordered_params = pattern_misordered_params(self.pcx)
-                    && let Some(matches) = CheckMirCtxt::new(
-                        self.tcx,
-                        self.pcx,
-                        body,
-                        pattern_misordered_params.pattern,
-                        pattern_misordered_params.fn_pat,
-                    )
-                    .check()
-                    && let Some(matches) = matches.first()
-                    && let Some(from_raw_parts) = matches[pattern_misordered_params.from_raw_parts]
-                    && let span = from_raw_parts.span_no_inline(body)
-                {
+                let pattern = pattern_misordered_params(self.pcx);
+                for matches in CheckMirCtxt::new(self.tcx, self.pcx, body, pattern.pattern, pattern.fn_pat).check() {
+                    let span = matches[pattern.from_raw_parts].span_no_inline(body);
                     debug!(?span);
                     self.tcx.dcx().emit_err(crate::errors::MisorderedParameters { span });
                 }

--- a/crates/rpl_patterns/src/cve_2019_15548.rs
+++ b/crates/rpl_patterns/src/cve_2019_15548.rs
@@ -55,16 +55,12 @@ impl<'tcx> Visitor<'tcx> for CheckFnCtxt<'_, 'tcx> {
             && self.tcx.is_mir_available(def_id)
         {
             let body = self.tcx.optimized_mir(def_id);
-            #[allow(irrefutable_let_patterns)]
-            if let pattern_cast = pattern_rust_str_as_c_str(self.pcx)
-                && let Some(matches) =
-                    CheckMirCtxt::new(self.tcx, self.pcx, body, pattern_cast.pattern, pattern_cast.fn_pat).check()
-                && let Some(matches) = matches.first()
-                && let Some(cast_from) = matches[pattern_cast.cast_from]
-                && let cast_from = cast_from.span_no_inline(body)
-                && let Some(cast_to) = matches[pattern_cast.cast_to]
-                && let cast_to = cast_to.span_no_inline(body)
+            let pattern_cast = pattern_rust_str_as_c_str(self.pcx);
+            for matches in
+                CheckMirCtxt::new(self.tcx, self.pcx, body, pattern_cast.pattern, pattern_cast.fn_pat).check()
             {
+                let cast_from = matches[pattern_cast.cast_from].span_no_inline(body);
+                let cast_to = matches[pattern_cast.cast_to].span_no_inline(body);
                 debug!(?cast_from, ?cast_to);
                 self.tcx.emit_node_span_lint(
                     RUST_STRING_POINTER_AS_C_STRING_POINTER,
@@ -73,16 +69,13 @@ impl<'tcx> Visitor<'tcx> for CheckFnCtxt<'_, 'tcx> {
                     crate::errors::RustStrAsCStr { cast_from, cast_to },
                 );
             }
-            #[allow(irrefutable_let_patterns)]
-            if let pattern_cast = pattern_rust_str_as_c_str_inlined(self.pcx)
-                && let Some(matches) =
-                    CheckMirCtxt::new(self.tcx, self.pcx, body, pattern_cast.pattern, pattern_cast.fn_pat).check()
-                && let Some(matches) = matches.first()
-                && let Some(cast_from) = matches[pattern_cast.cast_from]
-                && let cast_from = cast_from.span_no_inline(body)
-                && let Some(cast_to) = matches[pattern_cast.cast_to]
-                && let cast_to = cast_to.span_no_inline(body)
+            let pattern_cast = pattern_rust_str_as_c_str_inlined(self.pcx);
+            for matches in
+                CheckMirCtxt::new(self.tcx, self.pcx, body, pattern_cast.pattern, pattern_cast.fn_pat).check()
             {
+                let cast_from = matches[pattern_cast.cast_from].span_no_inline(body);
+                let cast_to = matches[pattern_cast.cast_to].span_no_inline(body);
+
                 debug!(?cast_from, ?cast_to);
                 self.tcx.emit_node_span_lint(
                     RUST_STRING_POINTER_AS_C_STRING_POINTER,
@@ -91,14 +84,10 @@ impl<'tcx> Visitor<'tcx> for CheckFnCtxt<'_, 'tcx> {
                     crate::errors::RustStrAsCStr { cast_from, cast_to },
                 );
             }
-            #[allow(irrefutable_let_patterns)]
-            if let pattern_ptr = pattern_pass_a_pointer_to_c(self.pcx)
-                && let Some(matches) =
-                    CheckMirCtxt::new(self.tcx, self.pcx, body, pattern_ptr.pattern, pattern_ptr.fn_pat).check()
-                && let Some(matches) = matches.first()
-                && let Some(ptr) = matches[pattern_ptr.ptr]
-                && let ptr = ptr.span_no_inline(body)
+            let pattern_ptr = pattern_pass_a_pointer_to_c(self.pcx);
+            for matches in CheckMirCtxt::new(self.tcx, self.pcx, body, pattern_ptr.pattern, pattern_ptr.fn_pat).check()
             {
+                let ptr = matches[pattern_ptr.ptr].span_no_inline(body);
                 debug!(?ptr);
                 self.tcx.emit_node_span_lint(
                     LENGTHLESS_BUFFER_PASSED_TO_EXTERN_FUNCTION,

--- a/crates/rpl_patterns/src/cve_2020_35881.rs
+++ b/crates/rpl_patterns/src/cve_2020_35881.rs
@@ -48,21 +48,15 @@ pub mod const_const_Transmute_ver {
         ) -> Self::Result {
             if self.tcx.visibility(def_id).is_public() && self.tcx.is_mir_available(def_id) {
                 let body = self.tcx.optimized_mir(def_id);
-                #[allow(irrefutable_let_patterns)]
-                if let pattern = pattern_wrong_assumption_of_fat_pointer_layout(self.pcx)
-                    && let Some(matches) =
-                        CheckMirCtxt::new(self.tcx, self.pcx, body, pattern.pattern, pattern.fn_pat).check()
-                    && let Some(matches) = matches.first()
-                    && let Some(ptr_transmute) = matches[pattern.ptr_transmute]
-                    && let span1 = ptr_transmute.span_no_inline(body)
-                    && let Some(data_ptr_get) = matches[pattern.data_ptr_get]
-                    && let span2 = data_ptr_get.span_no_inline(body)
-                {
+                let pattern = pattern_wrong_assumption_of_fat_pointer_layout(self.pcx);
+                for matches in CheckMirCtxt::new(self.tcx, self.pcx, body, pattern.pattern, pattern.fn_pat).check() {
+                    let ptr_transmute = matches[pattern.ptr_transmute].span_no_inline(body);
+                    let data_ptr_get = matches[pattern.data_ptr_get].span_no_inline(body);
                     self.tcx
                         .dcx()
                         .emit_err(crate::errors::WrongAssumptionOfFatPointerLayout {
-                            ptr_transmute: span1,
-                            data_ptr_get: span2,
+                            ptr_transmute,
+                            data_ptr_get,
                         });
                 }
             }
@@ -158,21 +152,15 @@ pub mod mut_mut_Transmute_ver {
         ) -> Self::Result {
             if self.tcx.visibility(def_id).is_public() && self.tcx.is_mir_available(def_id) {
                 let body = self.tcx.optimized_mir(def_id);
-                #[allow(irrefutable_let_patterns)]
-                if let pattern = pattern_wrong_assumption_of_fat_pointer_layout(self.pcx)
-                    && let Some(matches) =
-                        CheckMirCtxt::new(self.tcx, self.pcx, body, pattern.pattern, pattern.fn_pat).check()
-                    && let Some(matches) = matches.first()
-                    && let Some(ptr_transmute) = matches[pattern.ptr_transmute]
-                    && let span1 = ptr_transmute.span_no_inline(body)
-                    && let Some(data_ptr_get) = matches[pattern.data_ptr_get]
-                    && let span2 = data_ptr_get.span_no_inline(body)
-                {
+                let pattern = pattern_wrong_assumption_of_fat_pointer_layout(self.pcx);
+                for matches in CheckMirCtxt::new(self.tcx, self.pcx, body, pattern.pattern, pattern.fn_pat).check() {
+                    let ptr_transmute = matches[pattern.ptr_transmute].span_no_inline(body);
+                    let data_ptr_get = matches[pattern.data_ptr_get].span_no_inline(body);
                     self.tcx
                         .dcx()
                         .emit_err(crate::errors::WrongAssumptionOfFatPointerLayout {
-                            ptr_transmute: span1,
-                            data_ptr_get: span2,
+                            ptr_transmute,
+                            data_ptr_get,
                         });
                 }
             }
@@ -269,21 +257,15 @@ pub mod mut_const_PtrToPtr_ver {
         ) -> Self::Result {
             if self.tcx.visibility(def_id).is_public() && self.tcx.is_mir_available(def_id) {
                 let body = self.tcx.optimized_mir(def_id);
-                #[allow(irrefutable_let_patterns)]
-                if let pattern = pattern_wrong_assumption_of_fat_pointer_layout(self.pcx)
-                    && let Some(matches) =
-                        CheckMirCtxt::new(self.tcx, self.pcx, body, pattern.pattern, pattern.fn_pat).check()
-                    && let Some(matches) = matches.first()
-                    && let Some(ptr_transmute) = matches[pattern.ptr_transmute]
-                    && let span1 = ptr_transmute.span_no_inline(body)
-                    && let Some(data_ptr_get) = matches[pattern.data_ptr_get]
-                    && let span2 = data_ptr_get.span_no_inline(body)
-                {
+                let pattern = pattern_wrong_assumption_of_fat_pointer_layout(self.pcx);
+                for matches in CheckMirCtxt::new(self.tcx, self.pcx, body, pattern.pattern, pattern.fn_pat).check() {
+                    let ptr_transmute = matches[pattern.ptr_transmute].span_no_inline(body);
+                    let data_ptr_get = matches[pattern.data_ptr_get].span_no_inline(body);
                     self.tcx
                         .dcx()
                         .emit_err(crate::errors::WrongAssumptionOfFatPointerLayout {
-                            ptr_transmute: span1,
-                            data_ptr_get: span2,
+                            ptr_transmute,
+                            data_ptr_get,
                         });
                 }
             }

--- a/crates/rpl_patterns/src/cve_2021_25904.rs
+++ b/crates/rpl_patterns/src/cve_2021_25904.rs
@@ -52,34 +52,20 @@ impl<'tcx> Visitor<'tcx> for CheckFnCtxt<'_, 'tcx> {
             && self.tcx.is_mir_available(def_id)
         {
             let body = self.tcx.optimized_mir(def_id);
-            #[allow(irrefutable_let_patterns)]
-            if let pattern = pattern_from_raw_parts_iter(self.pcx)
-                && let Some(matches) =
-                    CheckMirCtxt::new(self.tcx, self.pcx, body, pattern.pattern, pattern.fn_pat).check()
-                && let Some(matches) = matches.first()
-                && let Some(slice) = matches[pattern.slice]
-                && let slice = slice.span_no_inline(body)
-                && let Some(src) = matches[pattern.src]
-                && let src = src.span_no_inline(body)
-                && let Some(ptr) = matches[pattern.ptr]
-                && let ptr = ptr.span_no_inline(body)
-            {
+            let pattern = pattern_from_raw_parts_iter(self.pcx);
+            for matches in CheckMirCtxt::new(self.tcx, self.pcx, body, pattern.pattern, pattern.fn_pat).check() {
+                let slice = matches[pattern.slice].span_no_inline(body);
+                let src = matches[pattern.src].span_no_inline(body);
+                let ptr = matches[pattern.ptr].span_no_inline(body);
                 self.tcx
                     .dcx()
                     .emit_err(crate::errors::UnvalidatedSliceFromRawParts { src, ptr, slice });
             }
-            #[allow(irrefutable_let_patterns)]
-            if let pattern = pattern_from_raw_parts_iter_inlined(self.pcx)
-                && let Some(matches) =
-                    CheckMirCtxt::new(self.tcx, self.pcx, body, pattern.pattern, pattern.fn_pat).check()
-                && let Some(matches) = matches.first()
-                && let Some(slice) = matches[pattern.slice]
-                && let slice = slice.span_no_inline(body)
-                && let Some(src) = matches[pattern.src]
-                && let src = src.span_no_inline(body)
-                && let Some(ptr) = matches[pattern.ptr]
-                && let ptr = ptr.span_no_inline(body)
-            {
+            let pattern = pattern_from_raw_parts_iter_inlined(self.pcx);
+            for matches in CheckMirCtxt::new(self.tcx, self.pcx, body, pattern.pattern, pattern.fn_pat).check() {
+                let slice = matches[pattern.slice].span_no_inline(body);
+                let src = matches[pattern.src].span_no_inline(body);
+                let ptr = matches[pattern.ptr].span_no_inline(body);
                 self.tcx
                     .dcx()
                     .emit_err(crate::errors::UnvalidatedSliceFromRawParts { src, ptr, slice });

--- a/crates/rpl_patterns/src/cve_2021_27376.rs
+++ b/crates/rpl_patterns/src/cve_2021_27376.rs
@@ -48,44 +48,32 @@ impl<'tcx> Visitor<'tcx> for CheckFnCtxt<'_, 'tcx> {
     ) -> Self::Result {
         if self.tcx.is_mir_available(def_id) {
             let body = self.tcx.optimized_mir(def_id);
-            #[allow(irrefutable_let_patterns)]
-            if let pattern_cast = pattern_cast_socket_addr_v6(self.pcx)
-                && let Some(matches) =
-                    CheckMirCtxt::new(self.tcx, self.pcx, body, pattern_cast.pattern, pattern_cast.fn_pat).check()
-                && let Some(matches) = matches.first()
-                && let Some(cast_from) = matches[pattern_cast.cast_from]
-                && let cast_from = cast_from.span_no_inline(body)
-                && let Some(cast_to) = matches[pattern_cast.cast_to]
-                && let cast_to = cast_to.span_no_inline(body)
-            {
+            let pattern = pattern_cast_socket_addr_v6(self.pcx);
+            for matches in CheckMirCtxt::new(self.tcx, self.pcx, body, pattern.pattern, pattern.fn_pat).check() {
+                let cast_from = matches[pattern.cast_from].span_no_inline(body);
+                let cast_to = matches[pattern.cast_to].span_no_inline(body);
                 debug!(?cast_from, ?cast_to);
                 self.tcx
                     .dcx()
                     .emit_err(crate::errors::WrongAssumptionOfLayoutCompatibility {
                         cast_from,
                         cast_to,
-                        type_from: pattern_cast.type_from,
-                        type_to: pattern_cast.type_to,
+                        type_from: pattern.type_from,
+                        type_to: pattern.type_to,
                     });
             }
-            #[allow(irrefutable_let_patterns)]
-            if let pattern_cast = pattern_cast_socket_addr_v4(self.pcx)
-                && let Some(matches) =
-                    CheckMirCtxt::new(self.tcx, self.pcx, body, pattern_cast.pattern, pattern_cast.fn_pat).check()
-                && let Some(matches) = matches.first()
-                && let Some(cast_from) = matches[pattern_cast.cast_from]
-                && let cast_from = cast_from.span_no_inline(body)
-                && let Some(cast_to) = matches[pattern_cast.cast_to]
-                && let cast_to = cast_to.span_no_inline(body)
-            {
+            let pattern = pattern_cast_socket_addr_v4(self.pcx);
+            for matches in CheckMirCtxt::new(self.tcx, self.pcx, body, pattern.pattern, pattern.fn_pat).check() {
+                let cast_from = matches[pattern.cast_from].span_no_inline(body);
+                let cast_to = matches[pattern.cast_to].span_no_inline(body);
                 debug!(?cast_from, ?cast_to);
                 self.tcx
                     .dcx()
                     .emit_err(crate::errors::WrongAssumptionOfLayoutCompatibility {
                         cast_from,
                         cast_to,
-                        type_from: pattern_cast.type_from,
-                        type_to: pattern_cast.type_to,
+                        type_from: pattern.type_from,
+                        type_to: pattern.type_to,
                     });
             }
         }

--- a/crates/rpl_patterns/src/cve_2021_29941_2.rs
+++ b/crates/rpl_patterns/src/cve_2021_29941_2.rs
@@ -48,50 +48,32 @@ impl<'tcx> Visitor<'tcx> for CheckFnCtxt<'_, 'tcx> {
     ) -> Self::Result {
         if self.tcx.is_mir_available(def_id) {
             let body = self.tcx.optimized_mir(def_id);
-            #[allow(irrefutable_let_patterns)]
-            if let pattern = pattern_trust_len(self.pcx)
-                && let Some(matches) =
-                    CheckMirCtxt::new(self.tcx, self.pcx, body, pattern.pattern, pattern.fn_pat).check()
-                && let Some(matches) = matches.first()
-                && let Some(len) = matches[pattern.len]
-                && let len = len.span_no_inline(body)
-                && let Some(set_len) = matches[pattern.set_len]
-                && let set_len = set_len.span_no_inline(body)
-            {
+            let pattern = pattern_trust_len(self.pcx);
+            for matches in CheckMirCtxt::new(self.tcx, self.pcx, body, pattern.pattern, pattern.fn_pat).check() {
+                let len = matches[pattern.len].span_no_inline(body);
+                let set_len = matches[pattern.set_len].span_no_inline(body);
+
                 debug!(?len, ?set_len);
                 self.tcx
                     .dcx()
                     .emit_err(crate::errors::TrustExactSizeIterator { len, set_len });
             }
-            #[allow(irrefutable_let_patterns)]
-            if let pattern = pattern_trust_len_inlined(self.pcx)
-                && let Some(matches) =
-                    CheckMirCtxt::new(self.tcx, self.pcx, body, pattern.pattern, pattern.fn_pat).check()
-                && let Some(matches) = matches.first()
-                && let Some(len) = matches[pattern.len]
-                && let len = len.span_no_inline(body)
-                && let Some(set_len) = matches[pattern.set_len]
-                && let set_len = set_len.span_no_inline(body)
-            {
+            let pattern = pattern_trust_len_inlined(self.pcx);
+            for matches in CheckMirCtxt::new(self.tcx, self.pcx, body, pattern.pattern, pattern.fn_pat).check() {
+                let len = matches[pattern.len].span_no_inline(body);
+                let set_len = matches[pattern.set_len].span_no_inline(body);
                 debug!(?len, ?set_len);
                 self.tcx
                     .dcx()
                     .emit_err(crate::errors::TrustExactSizeIterator { len, set_len });
             }
-            #[allow(irrefutable_let_patterns)]
-            if let pattern = pattern_uninitialized_slice(self.pcx)
-                && let Some(matches) =
-                    CheckMirCtxt::new(self.tcx, self.pcx, body, pattern.pattern, pattern.fn_pat).check()
-                && let Some(matches) = matches.first()
-                && let Some(len) = matches[pattern.len]
-                && let len = len.span_no_inline(body)
-                && let Some(ptr) = matches[pattern.ptr]
-                && let ptr = ptr.span_no_inline(body)
-                && let Some(vec) = matches[pattern.vec]
-                && let vec = vec.span_no_inline(body)
-                && let Some(slice) = matches[pattern.slice]
-                && let slice = slice.span_no_inline(body)
-            {
+            let pattern = pattern_uninitialized_slice(self.pcx);
+            for matches in CheckMirCtxt::new(self.tcx, self.pcx, body, pattern.pattern, pattern.fn_pat).check() {
+                let len = matches[pattern.len].span_no_inline(body);
+                let ptr = matches[pattern.ptr].span_no_inline(body);
+                let vec = matches[pattern.vec].span_no_inline(body);
+                let slice = matches[pattern.slice].span_no_inline(body);
+
                 debug!(?len, ?ptr, ?vec, ?slice);
                 self.tcx.dcx().emit_err(crate::errors::SliceFromRawPartsUninitialized {
                     len,
@@ -101,20 +83,13 @@ impl<'tcx> Visitor<'tcx> for CheckFnCtxt<'_, 'tcx> {
                     fn_name: "std::slice::from_raw_parts",
                 });
             }
-            #[allow(irrefutable_let_patterns)]
-            if let pattern = pattern_uninitialized_slice_inlined(self.pcx)
-                && let Some(matches) =
-                    CheckMirCtxt::new(self.tcx, self.pcx, body, pattern.pattern, pattern.fn_pat).check()
-                && let Some(matches) = matches.first()
-                && let Some(len) = matches[pattern.len]
-                && let len = len.span_no_inline(body)
-                && let Some(ptr) = matches[pattern.ptr]
-                && let ptr = ptr.span_no_inline(body)
-                && let Some(vec) = matches[pattern.vec]
-                && let vec = vec.span_no_inline(body)
-                && let Some(slice) = matches[pattern.slice]
-                && let slice = slice.span_no_inline(body)
-            {
+            let pattern = pattern_uninitialized_slice_inlined(self.pcx);
+            for matches in CheckMirCtxt::new(self.tcx, self.pcx, body, pattern.pattern, pattern.fn_pat).check() {
+                let len = matches[pattern.len].span_no_inline(body);
+                let ptr = matches[pattern.ptr].span_no_inline(body);
+                let vec = matches[pattern.vec].span_no_inline(body);
+                let slice = matches[pattern.slice].span_no_inline(body);
+
                 debug!(?len, ?ptr, ?vec, ?slice);
                 self.tcx.dcx().emit_err(crate::errors::SliceFromRawPartsUninitialized {
                     len,
@@ -124,20 +99,13 @@ impl<'tcx> Visitor<'tcx> for CheckFnCtxt<'_, 'tcx> {
                     fn_name: "std::slice::from_raw_parts",
                 });
             }
-            #[allow(irrefutable_let_patterns)]
-            if let pattern = pattern_uninitialized_slice_mut(self.pcx)
-                && let Some(matches) =
-                    CheckMirCtxt::new(self.tcx, self.pcx, body, pattern.pattern, pattern.fn_pat).check()
-                && let Some(matches) = matches.first()
-                && let Some(len) = matches[pattern.len]
-                && let len = len.span_no_inline(body)
-                && let Some(ptr) = matches[pattern.ptr]
-                && let ptr = ptr.span_no_inline(body)
-                && let Some(vec) = matches[pattern.vec]
-                && let vec = vec.span_no_inline(body)
-                && let Some(slice) = matches[pattern.slice]
-                && let slice = slice.span_no_inline(body)
-            {
+            let pattern = pattern_uninitialized_slice_mut(self.pcx);
+            for matches in CheckMirCtxt::new(self.tcx, self.pcx, body, pattern.pattern, pattern.fn_pat).check() {
+                let len = matches[pattern.len].span_no_inline(body);
+                let ptr = matches[pattern.ptr].span_no_inline(body);
+                let vec = matches[pattern.vec].span_no_inline(body);
+                let slice = matches[pattern.slice].span_no_inline(body);
+
                 debug!(?len, ?ptr, ?vec, ?slice);
                 self.tcx.dcx().emit_err(crate::errors::SliceFromRawPartsUninitialized {
                     len,
@@ -147,20 +115,12 @@ impl<'tcx> Visitor<'tcx> for CheckFnCtxt<'_, 'tcx> {
                     fn_name: "std::slice::from_raw_parts_mut",
                 });
             }
-            #[allow(irrefutable_let_patterns)]
-            if let pattern = pattern_uninitialized_slice_mut_inlined(self.pcx)
-                && let Some(matches) =
-                    CheckMirCtxt::new(self.tcx, self.pcx, body, pattern.pattern, pattern.fn_pat).check()
-                && let Some(matches) = matches.first()
-                && let Some(len) = matches[pattern.len]
-                && let len = len.span_no_inline(body)
-                && let Some(ptr) = matches[pattern.ptr]
-                && let ptr = ptr.span_no_inline(body)
-                && let Some(vec) = matches[pattern.vec]
-                && let vec = vec.span_no_inline(body)
-                && let Some(slice) = matches[pattern.slice]
-                && let slice = slice.span_no_inline(body)
-            {
+            let pattern = pattern_uninitialized_slice_mut_inlined(self.pcx);
+            for matches in CheckMirCtxt::new(self.tcx, self.pcx, body, pattern.pattern, pattern.fn_pat).check() {
+                let len = matches[pattern.len].span_no_inline(body);
+                let ptr = matches[pattern.ptr].span_no_inline(body);
+                let vec = matches[pattern.vec].span_no_inline(body);
+                let slice = matches[pattern.slice].span_no_inline(body);
                 debug!(?len, ?ptr, ?vec, ?slice);
                 self.tcx.dcx().emit_err(crate::errors::SliceFromRawPartsUninitialized {
                     len,
@@ -335,13 +295,18 @@ fn pattern_uninitialized_slice_mut(pcx: PatCtxt<'_>) -> PatternFromRawParts<'_> 
     let pattern = rpl! {
         #[meta($T:ty)]
         fn $pattern (..) -> _ = mir! {
-            #[export(len)]
-            let len: usize = _;
+            // #[export(len)]
+            // let len: usize = _;
             #[export(vec)]
             let vec: alloc::vec::Vec<$T> = alloc::vec::Vec::with_capacity(_);
             let vec_ref: &mut alloc::vec::Vec<$T> = &mut vec;
             #[export(ptr)]
             let ptr: *mut $T = alloc::vec::Vec::as_mut_ptr(move vec_ref);
+            // FIXME: if this statement is put in the beginning, it may fail to match the cdoe where
+            // `Vec::with_capacity` is called in advance of `ExactSizeIterator::len`.
+            // See `rpl_mir::matches::match_block_ends_with` for more details.
+            #[export(len)]
+            let len: usize = _;
             #[export(slice)]
             let slice: &mut [$T] = std::slice::from_raw_parts_mut::<'_, $T>(move ptr, move len);
         }
@@ -367,8 +332,8 @@ fn pattern_uninitialized_slice_mut_inlined(pcx: PatCtxt<'_>) -> PatternFromRawPa
     let pattern = rpl! {
         #[meta($T:ty)]
         fn $pattern (..) -> _ = mir! {
-            #[export(len)]
-            let len: usize = _;
+            // #[export(len)]
+            // let len: usize = _;
 
             // let vec: std::vec::Vec<$T> = std::vec::Vec::with_capacity(_);
             let raw_vec_inner: alloc::raw_vec::RawVecInner = alloc::raw_vec::RawVecInner::with_capacity_in(_, _, _);
@@ -390,6 +355,13 @@ fn pattern_uninitialized_slice_mut_inlined(pcx: PatCtxt<'_>) -> PatternFromRawPa
 
             // #[export(slice)]
             // let slice: &mut [$T] = std::slice::from_raw_parts_mut::<'_, $T>(move ptr, copy len);
+
+            // FIXME: if this statement is put in the beginning, it may fail to match the cdoe where
+            // `Vec::with_capacity` is called in advance of `ExactSizeIterator::len`.
+            // See `rpl_mir::matches::match_block_ends_with` for more details.
+            #[export(len)]
+            let len: usize = _;
+
             let slice_ptr: *mut [$T] = *mut [$T] from (copy ptr, copy len);
             #[export(slice)]
             let slice: &mut [$T] = &mut *slice_ptr;

--- a/crates/rpl_patterns/src/errors.rs
+++ b/crates/rpl_patterns/src/errors.rs
@@ -136,10 +136,12 @@ pub struct SliceFromRawPartsUninitialized {
 // use `Vec::set_len` to extend the length of a `Vec` without initializing the new elements
 #[derive(Diagnostic)]
 #[diag(rpl_patterns_vec_set_len_to_extend)]
+#[note]
 pub struct VecSetLenToExtend {
     #[primary_span]
-    #[note]
-    pub span: Span,
+    pub set_len: Span,
+    #[label]
+    pub vec: Span,
 }
 
 // for cve_2018_20992

--- a/tests/ui/cve_2018_20992/cve_2018_20992.rs
+++ b/tests/ui/cve_2018_20992/cve_2018_20992.rs
@@ -6,6 +6,7 @@ pub fn ensure_buffer_len(mut buffer: Vec<i32>, new_len: usize) -> Vec<i32> {
         unsafe {
             buffer.set_len(new_len);
             //~^ ERROR: Use `Vec::set_len` to extend the length of a `Vec`, potentially including uninitialized elements
+            //~| ERROR: Use `Vec::set_len` to extend the length of a `Vec`, potentially including uninitialized elements
         }
     } else {
         buffer.truncate(new_len);

--- a/tests/ui/cve_2018_20992/cve_2018_20992.stderr
+++ b/tests/ui/cve_2018_20992/cve_2018_20992.stderr
@@ -1,14 +1,24 @@
 error: Use `Vec::set_len` to extend the length of a `Vec`, potentially including uninitialized elements
   --> tests/ui/cve_2018_20992/cve_2018_20992.rs:7:20
    |
+LL | pub fn ensure_buffer_len(mut buffer: Vec<i32>, new_len: usize) -> Vec<i32> {
+   |                          ---------- `Vec` created here
+...
 LL |             buffer.set_len(new_len);
    |                    ^^^^^^^^^^^^^^^^
    |
-note: make sure all elements are initialized before using them
+   = note: make sure all elements are initialized before using them
+
+error: Use `Vec::set_len` to extend the length of a `Vec`, potentially including uninitialized elements
   --> tests/ui/cve_2018_20992/cve_2018_20992.rs:7:20
    |
+LL |             buffer = Vec::with_capacity(new_len);
+   |             ------ `Vec` created here
+...
 LL |             buffer.set_len(new_len);
    |                    ^^^^^^^^^^^^^^^^
+   |
+   = note: make sure all elements are initialized before using them
 
-error: aborting due to 1 previous error
+error: aborting due to 2 previous errors
 

--- a/tests/ui/cve_2019_16138/src/lib.stderr
+++ b/tests/ui/cve_2019_16138/src/lib.stderr
@@ -1,14 +1,13 @@
 error: Use `Vec::set_len` to extend the length of a `Vec`, potentially including uninitialized elements
   --> tests/ui/cve_2019_16138/src/lib.rs:200:25
    |
+LL |                 let mut ret = Vec::with_capacity(pixel_count);
+   |                               ------------------------------- `Vec` created here
+...
 LL |                     ret.set_len(pixel_count);
    |                         ^^^^^^^^^^^^^^^^^^^^
    |
-note: make sure all elements are initialized before using them
-  --> tests/ui/cve_2019_16138/src/lib.rs:200:25
-   |
-LL |                     ret.set_len(pixel_count);
-   |                         ^^^^^^^^^^^^^^^^^^^^
+   = note: make sure all elements are initialized before using them
 
 error: it violates the precondition of `Vec::set_len` to extend a `Vec`'s length without initializing its content in advance
   --> tests/ui/cve_2019_16138/src/lib.rs:200:25

--- a/tests/ui/cve_2021_25904/cve_2021_25904.stderr
+++ b/tests/ui/cve_2021_25904/cve_2021_25904.stderr
@@ -1,8 +1,8 @@
 error: it is unsound to trust pointers from passed-in iterators in a public safe function
-  --> tests/ui/cve_2021_25904/cve_2021_25904.rs:439:39
+  --> tests/ui/cve_2021_25904/cve_2021_25904.rs:439:50
    |
 LL |     pub fn copy_from_raw_parts<I, IU>(&mut self, mut src: I, mut src_linesize: IU)
-   |                                       ^^^^^^^^^
+   |                                                  ^^^^^^^
 ...
 LL |                 let rr = src.next().unwrap();
    |                                     -------- pointer created here

--- a/tests/ui/cve_2021_25904/cve_2021_25904_not_inlined.stderr
+++ b/tests/ui/cve_2021_25904/cve_2021_25904_not_inlined.stderr
@@ -1,8 +1,8 @@
 error: it is unsound to trust pointers from passed-in iterators in a public safe function
-  --> tests/ui/cve_2021_25904/cve_2021_25904_not_inlined.rs:441:39
+  --> tests/ui/cve_2021_25904/cve_2021_25904_not_inlined.rs:441:50
    |
 LL |     pub fn copy_from_raw_parts<I, IU>(&mut self, mut src: I, mut src_linesize: IU)
-   |                                       ^^^^^^^^^
+   |                                                  ^^^^^^^
 ...
 LL |                 let rr = src.next().unwrap();
    |                          ------------------- pointer created here

--- a/tests/ui/cve_2021_29941_2/cve_2021_29941_2.stderr
+++ b/tests/ui/cve_2021_29941_2/cve_2021_29941_2.stderr
@@ -1,14 +1,13 @@
 error: Use `Vec::set_len` to extend the length of a `Vec`, potentially including uninitialized elements
   --> tests/ui/cve_2021_29941_2/cve_2021_29941_2.rs:12:13
    |
+LL |     let mut vec = Vec::with_capacity(len);
+   |                   ----------------------- `Vec` created here
+...
 LL |         vec.set_len(len);
    |             ^^^^^^^^^^^^
    |
-note: make sure all elements are initialized before using them
-  --> tests/ui/cve_2021_29941_2/cve_2021_29941_2.rs:12:13
-   |
-LL |         vec.set_len(len);
-   |             ^^^^^^^^^^^^
+   = note: make sure all elements are initialized before using them
 
 error: it violates the precondition of `Vec::set_len` to extend a `Vec`'s length without initializing its content in advance
   --> tests/ui/cve_2021_29941_2/cve_2021_29941_2.rs:12:13

--- a/tests/ui/cve_2021_29941_2/cve_2021_29941_2_from_raw_parts.stderr
+++ b/tests/ui/cve_2021_29941_2/cve_2021_29941_2_from_raw_parts.stderr
@@ -1,14 +1,13 @@
 error: Use `Vec::set_len` to extend the length of a `Vec`, potentially including uninitialized elements
   --> tests/ui/cve_2021_29941_2/cve_2021_29941_2_from_raw_parts.rs:12:13
    |
+LL |     let mut vec = Vec::with_capacity(len);
+   |                   ----------------------- `Vec` created here
+...
 LL |         vec.set_len(len);
    |             ^^^^^^^^^^^^
    |
-note: make sure all elements are initialized before using them
-  --> tests/ui/cve_2021_29941_2/cve_2021_29941_2_from_raw_parts.rs:12:13
-   |
-LL |         vec.set_len(len);
-   |             ^^^^^^^^^^^^
+   = note: make sure all elements are initialized before using them
 
 error: it violates the precondition of `Vec::set_len` to extend a `Vec`'s length without initializing its content in advance
   --> tests/ui/cve_2021_29941_2/cve_2021_29941_2_from_raw_parts.rs:12:13

--- a/tests/ui/cve_2021_29941_2/cve_2021_29941_2_not_inlined.stderr
+++ b/tests/ui/cve_2021_29941_2/cve_2021_29941_2_not_inlined.stderr
@@ -12,8 +12,8 @@ LL |         vec.set_len(len);
 error: it is unsound to trust return value of `std::iter::ExactSizeIterator::len` and pass it to an unsafe function like `std::vec::Vec::set_len`, which may leak uninitialized memory
   --> tests/ui/cve_2021_29941_2/cve_2021_29941_2_not_inlined.rs:14:9
    |
-LL |     let arr: &mut [u32] = unsafe { std::slice::from_raw_parts_mut(vec.as_mut_ptr(), bla.len()) };
-   |                                                                                     --------- `std::iter::ExactSizeIterator::len` used here
+LL |     let len = bla.len();
+   |               --------- `std::iter::ExactSizeIterator::len` used here
 ...
 LL |         vec.set_len(len);
    |         ^^^^^^^^^^^^^^^^

--- a/tests/ui/cve_2021_29941_2/cve_2021_29941_2_range_ver.stderr
+++ b/tests/ui/cve_2021_29941_2/cve_2021_29941_2_range_ver.stderr
@@ -1,14 +1,13 @@
 error: Use `Vec::set_len` to extend the length of a `Vec`, potentially including uninitialized elements
   --> tests/ui/cve_2021_29941_2/cve_2021_29941_2_range_ver.rs:20:13
    |
+LL |     let mut vec = Vec::with_capacity(len);
+   |                   ----------------------- `Vec` created here
+...
 LL |         vec.set_len(len);
    |             ^^^^^^^^^^^^
    |
-note: make sure all elements are initialized before using them
-  --> tests/ui/cve_2021_29941_2/cve_2021_29941_2_range_ver.rs:20:13
-   |
-LL |         vec.set_len(len);
-   |             ^^^^^^^^^^^^
+   = note: make sure all elements are initialized before using them
 
 error: it violates the precondition of `Vec::set_len` to extend a `Vec`'s length without initializing its content in advance
   --> tests/ui/cve_2021_29941_2/cve_2021_29941_2_range_ver.rs:20:13

--- a/tests/ui/cve_2021_29941_2/cve_2021_29941_2_trust_len.stderr
+++ b/tests/ui/cve_2021_29941_2/cve_2021_29941_2_trust_len.stderr
@@ -1,14 +1,13 @@
 error: Use `Vec::set_len` to extend the length of a `Vec`, potentially including uninitialized elements
   --> tests/ui/cve_2021_29941_2/cve_2021_29941_2_trust_len.rs:12:13
    |
+LL |     let mut vec = Vec::new();
+   |                   ---------- `Vec` created here
+...
 LL |         vec.set_len(len);
    |             ^^^^^^^^^^^^
    |
-note: make sure all elements are initialized before using them
-  --> tests/ui/cve_2021_29941_2/cve_2021_29941_2_trust_len.rs:12:13
-   |
-LL |         vec.set_len(len);
-   |             ^^^^^^^^^^^^
+   = note: make sure all elements are initialized before using them
 
 error: it is unsound to trust return value of `std::iter::ExactSizeIterator::len` and pass it to an unsafe function like `std::vec::Vec::set_len`, which may leak uninitialized memory
   --> tests/ui/cve_2021_29941_2/cve_2021_29941_2_trust_len.rs:12:13

--- a/tests/ui/cve_2021_45688/cve_2021_45688.stderr
+++ b/tests/ui/cve_2021_45688/cve_2021_45688.stderr
@@ -1,14 +1,13 @@
 error: Use `Vec::set_len` to extend the length of a `Vec`, potentially including uninitialized elements
   --> tests/ui/cve_2021_45688/cve_2021_45688.rs:23:16
    |
+LL |     let mut result = Vec::<u32>::with_capacity(words);
+   |                      -------------------------------- `Vec` created here
+...
 LL |         result.set_len(words);
    |                ^^^^^^^^^^^^^^
    |
-note: make sure all elements are initialized before using them
-  --> tests/ui/cve_2021_45688/cve_2021_45688.rs:23:16
-   |
-LL |         result.set_len(words);
-   |                ^^^^^^^^^^^^^^
+   = note: make sure all elements are initialized before using them
 
 error: it violates the precondition of `Vec::set_len` to extend a `Vec`'s length without initializing its content in advance
   --> tests/ui/cve_2021_45688/cve_2021_45688.rs:23:16


### PR DESCRIPTION
1. Match type variables and local variables recursively in advance of matching statements, making sure that all type variables and local variables are traversed.
2. Fix `match_stmt_deps` where the matching logic was incorrect and interblock edges were not considered.
3. Fix `match_block` to use the terminator's matched result instead of block candidates. However, it still leaves some bugs when a pattern statement matches a statement or terminator behind the terminator that the current terminator of the pattern block matches, which leads to a data-dependency edge missing.
4. Remove the `pat::TerminatorKind::PatEnd` for candidate matching and graph matching since it is meaningless.
5. Fix `match_block_starts_with` to consider the interblock edges, but leave a FIXME that the current implementation is inefficient and probably missing control dependency edges when there are branches in the program.