### PR TITLE
Add one more pattern and corresponding tests for CVE-2020-35877

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,6 +13,8 @@ on:
     paths-ignore:
       - 'docs/**'
       - 'README.md'
+      - 'CONTRIBUTING.md'
+      - '.vscode/**'
 
 jobs:
   build:

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,4 +9,22 @@
     "lldb.showDisassembly": "auto",
     "lldb.dereferencePointers": true,
     "lldb.consoleMode": "commands",
+    "cSpell.words": [
+        "ctxt",
+        "graphviz",
+        "impls",
+        "libc",
+        "metavar",
+        "rustc",
+        "rustlib",
+        "rustup",
+        "rvalue",
+        "sockaddr",
+        "thir",
+        "TyKind",
+        "uibless",
+        "uitest",
+        "uninit",
+        "UnsafeCell"
+    ],
 }

--- a/README.md
+++ b/README.md
@@ -6,3 +6,5 @@
 A DSL for modeling Rust code patterns.
 
 See [this document](./CONTRIBUTING.md) for contribution-related instructions.
+
+See [this document](./docs/usage.md) for usage instructions.

--- a/crates/rpl_graphviz/tests/test.rs
+++ b/crates/rpl_graphviz/tests/test.rs
@@ -179,7 +179,7 @@ test_case! {
     }
 }
 
-test_case!{
+test_case! {
     fn cve_2020_35877() {
         meta!($T:ty);
 

--- a/crates/rpl_graphviz/tests/test.rs
+++ b/crates/rpl_graphviz/tests/test.rs
@@ -212,38 +212,6 @@ test_case! {
 }
 
 test_case! {
-    fn cve_2020_35877() {
-        meta!($T:ty);
-
-        let $offset: usize = _; // _2
-        let $offset_1: usize = copy $offset; // _3
-        let $ptr_1: *const $T = _; // _4
-        let $offset_2: usize = copy $offset_1; // _13
-        let $flag: bool = Gt(move $offset_2, const 0usize); // _12
-        let $ptr_3: *const $T; // _14
-        let $ptr_4: *const $T; // _15
-        let $reference: &$T; // _0
-        loop {
-            $offset_2 = copy $offset_1; // _13
-            $flag = Gt(move $offset_2, const 0usize); // _12
-            switchInt(move $flag) {
-                0usize => {
-                    $reference = &(*$ptr_1);
-                    break;
-                }
-                _ => {
-                    $offset_1 = Sub(copy $offset_1, const 1usize);
-                    $ptr_4 = copy $ptr_1;
-                    $ptr_3 = Offset(copy $ptr_4, _);
-                    $ptr_1 = move $ptr_3;
-                    continue;
-                }
-            }
-        }
-    }
-}
-
-test_case! {
     fn cve_2021_27376() {
         meta!();
 

--- a/crates/rpl_graphviz/tests/test.rs
+++ b/crates/rpl_graphviz/tests/test.rs
@@ -179,6 +179,38 @@ test_case! {
     }
 }
 
+test_case!{
+    fn cve_2020_35877() {
+        meta!($T:ty);
+
+        let $offset: usize = _; // _2
+        let $offset_1: usize = copy $offset; // _3
+        let $ptr_1: *const $T = _; // _4
+        let $offset_2: usize = copy $offset_1; // _13
+        let $flag: bool = Gt(move $offset_2, const 0usize); // _12
+        let $ptr_3: *const $T; // _14
+        let $ptr_4: *const $T; // _15
+        let $reference: &$T; // _0
+        loop {
+            $offset_2 = copy $offset_1; // _13
+            $flag = Gt(move $offset_2, const 0usize); // _12
+            switchInt(move $flag) {
+                0usize => {
+                    $reference = &(*$ptr_1);
+                    break;
+                }
+                _ => {
+                    $offset_1 = Sub(copy $offset_1, const 1usize);
+                    $ptr_4 = copy $ptr_1;
+                    $ptr_3 = Offset(copy $ptr_4, _);
+                    $ptr_1 = move $ptr_3;
+                    continue;
+                }
+            }
+        }
+    }
+}
+
 test_case! {
     fn cve_2020_35877() {
         meta!($T:ty);

--- a/crates/rpl_match/src/ty.rs
+++ b/crates/rpl_match/src/ty.rs
@@ -18,7 +18,7 @@ pub struct MatchTyCtxt<'pcx, 'tcx> {
     pub tcx: TyCtxt<'tcx>,
     pub pcx: PatCtxt<'pcx>,
     pub pat: &'pcx pat::Pattern<'pcx>,
-    param_env: ty::ParamEnv<'tcx>,
+    pub param_env: ty::ParamEnv<'tcx>,
     pub ty_vars: IndexVec<pat::TyVarIdx, RefCell<FxIndexSet<ty::Ty<'tcx>>>>,
     pub adt_matches: RefCell<FxHashMap<Symbol, FxHashMap<DefId, AdtMatch<'tcx>>>>,
 }

--- a/crates/rpl_mir/src/matches/mod.rs
+++ b/crates/rpl_mir/src/matches/mod.rs
@@ -691,9 +691,10 @@ impl<'a, 'pcx, 'tcx> MatchCtxt<'a, 'pcx, 'tcx> {
                         return false;
                     },
                 };
-                trace!("type variable {ty_var:?} matched: {ty:?}",);
+                let ty_var_matched = self.matching[ty_var].force_get_matched();
+                trace!("type variable {ty_var:?} matched: {ty_var_matched:?} matching: {ty:?}",);
                 // self.match_ty_var(ty_var, ty)
-                self.matching[ty_var].force_get_matched() == ty
+                ty_var_matched == ty
             })
     }
     #[instrument(level = "debug", skip(self), ret)]

--- a/crates/rpl_patterns/messages.en.ftl
+++ b/crates/rpl_patterns/messages.en.ftl
@@ -78,7 +78,7 @@ rpl_patterns_deref_null_pointer = Dereference of a possibly null pointer
     .deref_label = dereference here
     .note = this is because the pointer may be null
 
-rpl_patterns_unchecked_ptr_offset = it is unsound to dereference a pointer that is offset using an unchecked integer
+rpl_patterns_deref_unchecked_ptr_offset = it is unsound to dereference a pointer that is offset using an unchecked integer
     .reference_label = dereferenced here
     .ptr_label = pointer created here
     .offset_label = offset passed in here
@@ -87,3 +87,9 @@ rpl_patterns_unchecked_ptr_offset = it is unsound to dereference a pointer that 
 rpl_patterns_unsound_pin_project = it is unsound to call `Pin::new_unchecked` on a mutable reference that can be freely moved
     .label = mutable reference passed into a public function here
     .note = type `{$ty}` doesn't implement `Unpin`
+
+rpl_patterns_unchecked_ptr_offset = it is an undefined behavior to offset a pointer using an unchecked integer
+    .offset_label = offset here
+    .ptr_label = pointer created here
+    .help = check whether it's in bound before offsetting
+    .note = See the safety section in https://doc.rust-lang.org/std/primitive.pointer.html#method.offset

--- a/crates/rpl_patterns/messages.en.ftl
+++ b/crates/rpl_patterns/messages.en.ftl
@@ -90,6 +90,6 @@ rpl_patterns_unsound_pin_project = it is unsound to call `Pin::new_unchecked` on
 
 rpl_patterns_unchecked_ptr_offset = it is an undefined behavior to offset a pointer using an unchecked integer
     .offset_label = offset here
-    .ptr_label = pointer created here
+    .ptr_label = pointer used here
     .help = check whether it's in bound before offsetting
     .note = See the safety section in https://doc.rust-lang.org/std/primitive.pointer.html#method.offset

--- a/crates/rpl_patterns/src/errors.rs
+++ b/crates/rpl_patterns/src/errors.rs
@@ -264,12 +264,11 @@ pub struct UnsoundPinNewUnchecked<'tcx> {
 }
 
 // for cve_2020_35877
-#[derive(Diagnostic)]
+#[derive(LintDiagnostic)]
 #[diag(rpl_patterns_unchecked_ptr_offset)]
 #[help]
 #[note]
 pub struct UncheckedPtrOffset {
-    #[primary_span]
     #[label(rpl_patterns_offset_label)]
     pub offset: Span,
     #[label(rpl_patterns_ptr_label)]

--- a/crates/rpl_patterns/src/errors.rs
+++ b/crates/rpl_patterns/src/errors.rs
@@ -239,8 +239,9 @@ pub struct DerefNullPointer {
 
 // for cve_2020_35877
 #[derive(Diagnostic)]
-#[diag(rpl_patterns_unchecked_ptr_offset)]
-pub struct UncheckedPtrOffset {
+#[diag(rpl_patterns_deref_unchecked_ptr_offset)]
+#[help]
+pub struct DerefUncheckedPtrOffset {
     #[primary_span]
     #[label(rpl_patterns_reference_label)]
     pub reference: Span,
@@ -260,4 +261,17 @@ pub struct UnsoundPinNewUnchecked<'tcx> {
     #[label]
     pub mut_self: Span,
     pub ty: Ty<'tcx>,
+}
+
+// for cve_2020_35877
+#[derive(Diagnostic)]
+#[diag(rpl_patterns_unchecked_ptr_offset)]
+#[help]
+#[note]
+pub struct UncheckedPtrOffset {
+    #[primary_span]
+    #[label(rpl_patterns_offset_label)]
+    pub offset: Span,
+    #[label(rpl_patterns_ptr_label)]
+    pub ptr: Span,
 }

--- a/crates/rpl_patterns/src/lints.rs
+++ b/crates/rpl_patterns/src/lints.rs
@@ -68,3 +68,33 @@ declare_lint! {
     Deny,
     "detects a Rust string pointer used as a C string pointer directly"
 }
+
+declare_lint! {
+    /// The `unchecked_pointer_offset` lint detects a pointer that is offset using an unchecked integer.
+    /// This is a common source of undefined behavior.
+    ///
+    /// ### Example
+    ///
+    /// ```rust
+    /// #![deny(unchecked_pointer_offset)]
+    ///
+    /// fn index(p: *const u8, index: usize) -> *const u8 {
+    ///     unsafe {
+    ///         p.add(index)
+    ///     }
+    /// }
+    /// ```
+    ///
+    /// {{produces}}
+    ///
+    /// ### Explanation
+    ///
+    /// The `add` method is used to offset a pointer by a given number of elements.
+    /// However, if the index is not checked, it can lead to undefined behavior.
+    /// To avoid this, you should always check the index before offsetting the pointer,
+    /// unless both the pointer and the index are guaranteed to be valid, for example,
+    /// when the index is calculated from the length of the slice, or both are constants.
+    pub UNCHECKED_POINTER_OFFSET,
+    Deny,
+    "detects a pointer that is offset using an unchecked integer"
+}

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,0 +1,7 @@
+# Usage
+
+## The Pattern Language
+
+### Notes
+
+- When the operand has a `Copy` type, operator `Copy` or `Move` are considered equivalent.

--- a/tests/ui/cve_2020_35877/cve_2020_35877.rs
+++ b/tests/ui/cve_2020_35877/cve_2020_35877.rs
@@ -44,6 +44,7 @@ where
             while count > 0 {
                 count -= 1;
                 p = p.offset(1);
+                //~^ERROR: it is an undefined behavior to offset a pointer using an unchecked integer
             }
             &*p
             //~^ERROR: it is unsound to dereference a pointer that is offset using an unchecked integer

--- a/tests/ui/cve_2020_35877/cve_2020_35877.stderr
+++ b/tests/ui/cve_2020_35877/cve_2020_35877.stderr
@@ -32,7 +32,7 @@ error: it is an undefined behavior to offset a pointer using an unchecked intege
 LL |                 p = p.offset(1);
    |                     - ^^^^^^^^^ offset here
    |                     |
-   |                     pointer created here
+   |                     pointer used here
    |
    = help: check whether it's in bound before offsetting
    = note: See the safety section in https://doc.rust-lang.org/std/primitive.pointer.html#method.offset

--- a/tests/ui/cve_2020_35877/cve_2020_35877.stderr
+++ b/tests/ui/cve_2020_35877/cve_2020_35877.stderr
@@ -1,5 +1,5 @@
 error: it is unsound to dereference a pointer that is offset using an unchecked integer
-  --> tests/ui/cve_2020_35877/cve_2020_35877.rs:48:13
+  --> tests/ui/cve_2020_35877/cve_2020_35877.rs:49:13
    |
 LL |     fn index(&self, idx: usize) -> &Self::Output {
    |                     --- offset passed in here
@@ -9,18 +9,33 @@ LL |             let mut p: *const T = self.data.lock().unwrap().ptr() as *const
 ...
 LL |             &*p
    |             ^^^ dereferenced here
+   |
+   = help: check whether it's in bound before dereferencing
 
 error: it is unsound to dereference a pointer that is offset using an unchecked integer
-  --> tests/ui/cve_2020_35877/cve_2020_35877.rs:48:13
+  --> tests/ui/cve_2020_35877/cve_2020_35877.rs:49:13
    |
 LL |     fn index(&self, idx: usize) -> &Self::Output {
    |                     --- offset passed in here
 ...
 LL |                 p = p.offset(1);
    |                 --------------- pointer created here
-LL |             }
+...
 LL |             &*p
    |             ^^^ dereferenced here
+   |
+   = help: check whether it's in bound before dereferencing
 
-error: aborting due to 2 previous errors
+error: it is an undefined behavior to offset a pointer using an unchecked integer
+  --> tests/ui/cve_2020_35877/cve_2020_35877.rs:46:23
+   |
+LL |                 p = p.offset(1);
+   |                     - ^^^^^^^^^ offset here
+   |                     |
+   |                     pointer created here
+   |
+   = help: check whether it's in bound before offsetting
+   = note: See the safety section in https://doc.rust-lang.org/std/primitive.pointer.html#method.offset
+
+error: aborting due to 3 previous errors
 

--- a/tests/ui/cve_2020_35877/cve_2020_35877.stderr
+++ b/tests/ui/cve_2020_35877/cve_2020_35877.stderr
@@ -36,6 +36,7 @@ LL |                 p = p.offset(1);
    |
    = help: check whether it's in bound before offsetting
    = note: See the safety section in https://doc.rust-lang.org/std/primitive.pointer.html#method.offset
+   = note: `#[deny(unchecked_pointer_offset)]` on by default
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/cve_2020_35877/minimal.rs
+++ b/tests/ui/cve_2020_35877/minimal.rs
@@ -31,12 +31,9 @@ fn checked_lt<T>(slice: &[T], index: usize) -> &T {
 fn checked_le<T>(ptr: *const T, index: usize, length: usize) -> *const T {
     unsafe {
         let mut p = ptr;
-        // Unlike other functions, the MIR isn't using `copy`, so the pattern fails to match
-        // _5 = Le(move _6, copy _3);
+        // Though `index + 1` is moved in MIR, the negative pattern is still detected, so no false positive here
         assert!(index + 1 <= length);
         p = p.add(index);
-        //~^ERROR: it is an undefined behavior to offset a pointer using an unchecked integer
-        //FIXME: the error above is a false positive
         p
     }
 }

--- a/tests/ui/cve_2020_35877/minimal.rs
+++ b/tests/ui/cve_2020_35877/minimal.rs
@@ -54,6 +54,28 @@ fn safe_unchecked<T>(slice: &[T; 2]) -> &T {
     //FIXME: this is a false positive
 }
 
+fn safe_unchecked_2_const<T, const N: usize>(slice: &[T; N], index: usize) -> &T {
+    let ptr = slice.as_ptr();
+    unsafe { &*ptr.add(index % N) }
+    //~^ERROR: it is an undefined behavior to offset a pointer using an unchecked integer
+    //FIXME: this is a false positive
+}
+
+fn safe_unchecked_2_const_literal_2<T>(slice: &[T; 2], index: usize) -> &T {
+    let ptr = slice.as_ptr();
+    unsafe { &*ptr.add(index % 2) }
+    //~^ERROR: it is an undefined behavior to offset a pointer using an unchecked integer
+    //FIXME: this is a false positive
+}
+
+fn safe_unchecked_2<T>(slice: &[T], index: usize) -> &T {
+    let ptr = slice.as_ptr();
+    let length = slice.len();
+    unsafe { &*ptr.add(index % length) }
+    //~^ERROR: it is an undefined behavior to offset a pointer using an unchecked integer
+    //FIXME: this is a false positive
+}
+
 fn safe_unchecked_without_offset<T>(slice: &[T; 2]) -> &T {
     &slice[1]
 }

--- a/tests/ui/cve_2020_35877/minimal.rs
+++ b/tests/ui/cve_2020_35877/minimal.rs
@@ -57,23 +57,35 @@ fn safe_unchecked<T>(slice: &[T; 2]) -> &T {
 fn safe_unchecked_2_const<T, const N: usize>(slice: &[T; N], index: usize) -> &T {
     let ptr = slice.as_ptr();
     unsafe { &*ptr.add(index % N) }
-    //~^ERROR: it is an undefined behavior to offset a pointer using an unchecked integer
-    //FIXME: this is a false positive
 }
 
 fn safe_unchecked_2_const_literal_2<T>(slice: &[T; 2], index: usize) -> &T {
     let ptr = slice.as_ptr();
     unsafe { &*ptr.add(index % 2) }
-    //~^ERROR: it is an undefined behavior to offset a pointer using an unchecked integer
-    //FIXME: this is a false positive
+}
+
+fn safe_unchecked_2_const_literal_0<T>(slice: &[T; 0], index: usize) -> &T {
+    let ptr = slice.as_ptr();
+    unsafe { &*ptr.add(index % 0) }
+    //~^ERROR: this operation will panic at runtime
+}
+
+fn safe_unchecked_2_mismatched<T>(slice: &[T], index: usize) -> &T {
+    let ptr = slice.as_ptr();
+    unsafe { &*ptr.add(index % 2) }
+    //FIXME: this is a false negative
+}
+
+fn safe_unchecked_2_const_literal_2_3_mismatched<T>(slice: &[T; 2], index: usize) -> &T {
+    let ptr = slice.as_ptr();
+    unsafe { &*ptr.add(index % 3) }
+    //FIXME: this is a false negative
 }
 
 fn safe_unchecked_2<T>(slice: &[T], index: usize) -> &T {
     let ptr = slice.as_ptr();
     let length = slice.len();
     unsafe { &*ptr.add(index % length) }
-    //~^ERROR: it is an undefined behavior to offset a pointer using an unchecked integer
-    //FIXME: this is a false positive
 }
 
 fn safe_unchecked_without_offset<T>(slice: &[T; 2]) -> &T {

--- a/tests/ui/cve_2020_35877/minimal.rs
+++ b/tests/ui/cve_2020_35877/minimal.rs
@@ -1,0 +1,51 @@
+fn unchecked<T>(ptr: *const T, index: usize, length: usize) -> *const T {
+    unsafe {
+        let mut p = ptr;
+        p = p.add(index);
+        //~^ERROR: it is an undefined behavior to offset a pointer using an unchecked integer
+        p
+    }
+}
+
+fn unchecked_slice<T>(slice: &[T], index: usize) -> *const T {
+    let mut p = slice.as_ptr();
+    let length = slice.len();
+    unsafe {
+        p = p.add(index);
+        //~^ERROR: it is an undefined behavior to offset a pointer using an unchecked integer
+        &*p
+    }
+}
+
+// #[rpl::dump_mir(dump_cfg, dump_ddg)]
+fn checked_lt<T>(slice: &[T], index: usize) -> &T {
+    let mut p: *const T = slice.as_ptr();
+    let length: usize = slice.len();
+    assert!(index < length);
+    unsafe {
+        p = p.add(index);
+        &*p
+    }
+}
+
+fn checked_le<T>(ptr: *const T, index: usize, length: usize) -> *const T {
+    unsafe {
+        let mut p = ptr;
+        // Unlike other functions, the MIR isn't using `copy`, so the pattern fails to match
+        // _5 = Le(move _6, copy _3);
+        assert!(index + 1 <= length);
+        p = p.add(index);
+        //~^ERROR: it is an undefined behavior to offset a pointer using an unchecked integer
+        //FIXME: the error above is a false positive
+        p
+    }
+}
+
+fn checked_le_1<T>(ptr: *const T, index: usize, right: usize) -> *const T {
+    unsafe {
+        let mut p = ptr;
+        assert!(index <= right);
+        p = p.add(index);
+        p
+    }
+}

--- a/tests/ui/cve_2020_35877/minimal.rs
+++ b/tests/ui/cve_2020_35877/minimal.rs
@@ -46,3 +46,19 @@ fn checked_le_1<T>(ptr: *const T, index: usize, right: usize) -> *const T {
         p
     }
 }
+
+fn safe_unchecked<T>(slice: &[T; 2]) -> &T {
+    let ptr = slice.as_ptr();
+    unsafe { &*ptr.add(1) }
+    //~^ERROR: it is an undefined behavior to offset a pointer using an unchecked integer
+    //FIXME: this is a false positive
+}
+
+fn safe_unchecked_without_offset<T>(slice: &[T; 2]) -> &T {
+    &slice[1]
+}
+
+unsafe fn unsafe_unchecked<T>(p: *const T) -> *const T {
+    // Do anything you want with `p`, as it's in an `unsafe` function
+    unsafe { p.add(1) }
+}

--- a/tests/ui/cve_2020_35877/minimal.stderr
+++ b/tests/ui/cve_2020_35877/minimal.stderr
@@ -31,5 +31,39 @@ LL |     unsafe { &*ptr.add(1) }
    = help: check whether it's in bound before offsetting
    = note: See the safety section in https://doc.rust-lang.org/std/primitive.pointer.html#method.offset
 
-error: aborting due to 3 previous errors
+error: it is an undefined behavior to offset a pointer using an unchecked integer
+  --> tests/ui/cve_2020_35877/minimal.rs:59:20
+   |
+LL |     let ptr = slice.as_ptr();
+   |                     -------- pointer used here
+LL |     unsafe { &*ptr.add(index % N) }
+   |                    ^^^^^^^^^^^^^^ offset here
+   |
+   = help: check whether it's in bound before offsetting
+   = note: See the safety section in https://doc.rust-lang.org/std/primitive.pointer.html#method.offset
+
+error: it is an undefined behavior to offset a pointer using an unchecked integer
+  --> tests/ui/cve_2020_35877/minimal.rs:66:20
+   |
+LL |     let ptr = slice.as_ptr();
+   |                     -------- pointer used here
+LL |     unsafe { &*ptr.add(index % 2) }
+   |                    ^^^^^^^^^^^^^^ offset here
+   |
+   = help: check whether it's in bound before offsetting
+   = note: See the safety section in https://doc.rust-lang.org/std/primitive.pointer.html#method.offset
+
+error: it is an undefined behavior to offset a pointer using an unchecked integer
+  --> tests/ui/cve_2020_35877/minimal.rs:74:20
+   |
+LL |     let ptr = slice.as_ptr();
+   |                     -------- pointer used here
+LL |     let length = slice.len();
+LL |     unsafe { &*ptr.add(index % length) }
+   |                    ^^^^^^^^^^^^^^^^^^^ offset here
+   |
+   = help: check whether it's in bound before offsetting
+   = note: See the safety section in https://doc.rust-lang.org/std/primitive.pointer.html#method.offset
+
+error: aborting due to 6 previous errors
 

--- a/tests/ui/cve_2020_35877/minimal.stderr
+++ b/tests/ui/cve_2020_35877/minimal.stderr
@@ -8,6 +8,7 @@ LL |         p = p.add(index);
    |
    = help: check whether it's in bound before offsetting
    = note: See the safety section in https://doc.rust-lang.org/std/primitive.pointer.html#method.offset
+   = note: `#[deny(unchecked_pointer_offset)]` on by default
 
 error: it is an undefined behavior to offset a pointer using an unchecked integer
   --> tests/ui/cve_2020_35877/minimal.rs:14:15
@@ -31,39 +32,13 @@ LL |     unsafe { &*ptr.add(1) }
    = help: check whether it's in bound before offsetting
    = note: See the safety section in https://doc.rust-lang.org/std/primitive.pointer.html#method.offset
 
-error: it is an undefined behavior to offset a pointer using an unchecked integer
-  --> tests/ui/cve_2020_35877/minimal.rs:59:20
+error: this operation will panic at runtime
+  --> tests/ui/cve_2020_35877/minimal.rs:69:24
    |
-LL |     let ptr = slice.as_ptr();
-   |                     -------- pointer used here
-LL |     unsafe { &*ptr.add(index % N) }
-   |                    ^^^^^^^^^^^^^^ offset here
+LL |     unsafe { &*ptr.add(index % 0) }
+   |                        ^^^^^^^^^ attempt to calculate the remainder of `_` with a divisor of zero
    |
-   = help: check whether it's in bound before offsetting
-   = note: See the safety section in https://doc.rust-lang.org/std/primitive.pointer.html#method.offset
+   = note: `#[deny(unconditional_panic)]` on by default
 
-error: it is an undefined behavior to offset a pointer using an unchecked integer
-  --> tests/ui/cve_2020_35877/minimal.rs:66:20
-   |
-LL |     let ptr = slice.as_ptr();
-   |                     -------- pointer used here
-LL |     unsafe { &*ptr.add(index % 2) }
-   |                    ^^^^^^^^^^^^^^ offset here
-   |
-   = help: check whether it's in bound before offsetting
-   = note: See the safety section in https://doc.rust-lang.org/std/primitive.pointer.html#method.offset
-
-error: it is an undefined behavior to offset a pointer using an unchecked integer
-  --> tests/ui/cve_2020_35877/minimal.rs:74:20
-   |
-LL |     let ptr = slice.as_ptr();
-   |                     -------- pointer used here
-LL |     let length = slice.len();
-LL |     unsafe { &*ptr.add(index % length) }
-   |                    ^^^^^^^^^^^^^^^^^^^ offset here
-   |
-   = help: check whether it's in bound before offsetting
-   = note: See the safety section in https://doc.rust-lang.org/std/primitive.pointer.html#method.offset
-
-error: aborting due to 6 previous errors
+error: aborting due to 4 previous errors
 

--- a/tests/ui/cve_2020_35877/minimal.stderr
+++ b/tests/ui/cve_2020_35877/minimal.stderr
@@ -1,0 +1,35 @@
+error: it is an undefined behavior to offset a pointer using an unchecked integer
+  --> tests/ui/cve_2020_35877/minimal.rs:4:15
+   |
+LL |         p = p.add(index);
+   |             - ^^^^^^^^^^ offset here
+   |             |
+   |             pointer used here
+   |
+   = help: check whether it's in bound before offsetting
+   = note: See the safety section in https://doc.rust-lang.org/std/primitive.pointer.html#method.offset
+
+error: it is an undefined behavior to offset a pointer using an unchecked integer
+  --> tests/ui/cve_2020_35877/minimal.rs:14:15
+   |
+LL |         p = p.add(index);
+   |             - ^^^^^^^^^^ offset here
+   |             |
+   |             pointer used here
+   |
+   = help: check whether it's in bound before offsetting
+   = note: See the safety section in https://doc.rust-lang.org/std/primitive.pointer.html#method.offset
+
+error: it is an undefined behavior to offset a pointer using an unchecked integer
+  --> tests/ui/cve_2020_35877/minimal.rs:37:15
+   |
+LL |         p = p.add(index);
+   |             - ^^^^^^^^^^ offset here
+   |             |
+   |             pointer used here
+   |
+   = help: check whether it's in bound before offsetting
+   = note: See the safety section in https://doc.rust-lang.org/std/primitive.pointer.html#method.offset
+
+error: aborting due to 3 previous errors
+

--- a/tests/ui/cve_2020_35877/minimal.stderr
+++ b/tests/ui/cve_2020_35877/minimal.stderr
@@ -20,16 +20,5 @@ LL |         p = p.add(index);
    = help: check whether it's in bound before offsetting
    = note: See the safety section in https://doc.rust-lang.org/std/primitive.pointer.html#method.offset
 
-error: it is an undefined behavior to offset a pointer using an unchecked integer
-  --> tests/ui/cve_2020_35877/minimal.rs:37:15
-   |
-LL |         p = p.add(index);
-   |             - ^^^^^^^^^^ offset here
-   |             |
-   |             pointer used here
-   |
-   = help: check whether it's in bound before offsetting
-   = note: See the safety section in https://doc.rust-lang.org/std/primitive.pointer.html#method.offset
-
-error: aborting due to 3 previous errors
+error: aborting due to 2 previous errors
 

--- a/tests/ui/cve_2020_35877/minimal.stderr
+++ b/tests/ui/cve_2020_35877/minimal.stderr
@@ -20,5 +20,16 @@ LL |         p = p.add(index);
    = help: check whether it's in bound before offsetting
    = note: See the safety section in https://doc.rust-lang.org/std/primitive.pointer.html#method.offset
 
-error: aborting due to 2 previous errors
+error: it is an undefined behavior to offset a pointer using an unchecked integer
+  --> tests/ui/cve_2020_35877/minimal.rs:52:20
+   |
+LL |     let ptr = slice.as_ptr();
+   |                     -------- pointer used here
+LL |     unsafe { &*ptr.add(1) }
+   |                    ^^^^^^ offset here
+   |
+   = help: check whether it's in bound before offsetting
+   = note: See the safety section in https://doc.rust-lang.org/std/primitive.pointer.html#method.offset
+
+error: aborting due to 3 previous errors
 

--- a/tests/ui/cve_2021_27376/src/minimal.rs
+++ b/tests/ui/cve_2021_27376/src/minimal.rs
@@ -1,0 +1,8 @@
+fn main() {
+    let s: *const core::net::SocketAddrV4 = core::ptr::null();
+    let t1 = s as *const libc::sockaddr;
+    //~^ ERROR: wrong assumption of layout compatibility from `std::net::SocketAddrV4` to `libc::sockaddr`
+    let s: *const core::net::SocketAddrV6 = core::ptr::null();
+    let t2 = s as *const libc::sockaddr;
+    //~^ ERROR: wrong assumption of layout compatibility from `std::net::SocketAddrV6` to `libc::sockaddr`
+}

--- a/tests/ui/cve_2021_27376/src/minimal.stderr
+++ b/tests/ui/cve_2021_27376/src/minimal.stderr
@@ -1,0 +1,28 @@
+error: wrong assumption of layout compatibility from `std::net::SocketAddrV6` to `libc::sockaddr`
+  --> tests/ui/cve_2021_27376/src/minimal.rs:6:14
+   |
+LL |     let t2 = s as *const libc::sockaddr;
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: it's not guaranteed by Rust standard library. See https://github.com/rust-lang/rust/pull/78802
+note: casted from this
+  --> tests/ui/cve_2021_27376/src/minimal.rs:6:14
+   |
+LL |     let t2 = s as *const libc::sockaddr;
+   |              ^
+
+error: wrong assumption of layout compatibility from `std::net::SocketAddrV4` to `libc::sockaddr`
+  --> tests/ui/cve_2021_27376/src/minimal.rs:3:14
+   |
+LL |     let t1 = s as *const libc::sockaddr;
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: it's not guaranteed by Rust standard library. See https://github.com/rust-lang/rust/pull/78802
+note: casted from this
+  --> tests/ui/cve_2021_27376/src/minimal.rs:3:14
+   |
+LL |     let t1 = s as *const libc::sockaddr;
+   |              ^
+
+error: aborting due to 2 previous errors
+


### PR DESCRIPTION
I may open an issue later for my proposal that adds a new operator (may be `Forward`) for `Copy` or `Move` to MIR pattern, so that the pattern can be more generalized.