### PR TITLE
Implement CVE-2020-35901

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -842,6 +842,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "pin-project"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfe2e71e1471fe07709406bf725f710b02927c9c54b2b5b2ec0e8087d97c327d"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6e859e6e5bd50440ab63c47e3ebabc90f26251f7c73c3d3e837b74a1cc3fa67"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.96",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -994,6 +1014,7 @@ dependencies = [
  "num-rational",
  "num-traits",
  "parking_lot",
+ "pin-project",
  "quote",
  "regex",
  "rpl_interface",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,7 @@ num-derive = "0.3"
 num-rational = "0.3.0"
 num-traits = "0.2.8"
 memmap = "0.5.0"
+pin-project = "1.0"
 
 [package]
 name = "rpl"
@@ -100,6 +101,7 @@ num-rational.workspace = true
 num-traits.workspace = true
 thiserror.workspace = true
 memmap.workspace = true
+pin-project.workspace = true
 
 [build-dependencies]
 rustc_tools_util.workspace = true

--- a/crates/rpl_pat_expand/src/expand.rs
+++ b/crates/rpl_pat_expand/src/expand.rs
@@ -801,6 +801,11 @@ impl ToTokens for ExpandPat<'_, &LocalDecl> {
                     rvalue_or_call,
                 })
                 .to_tokens(tokens);
+        } else if let PlaceLocalKind::SelfValue(_) = local.kind
+            && let Some(Export { inner, .. }) = export
+        {
+            let stmt = &inner.ident;
+            quote_each_token!(tokens #stmt = #ident;);
         }
     }
 }

--- a/crates/rpl_patterns/messages.en.ftl
+++ b/crates/rpl_patterns/messages.en.ftl
@@ -83,3 +83,7 @@ rpl_patterns_unchecked_ptr_offset = it is unsound to dereference a pointer that 
     .ptr_label = pointer created here
     .offset_label = offset passed in here
     .help = check whether it's in bound before dereferencing
+
+rpl_patterns_unsound_pin_project = it is unsound to call `Pin::new_unchecked` on a mutable reference that can be freely moved
+    .label = mutable reference here
+    .note = type `{$ty}` doesn't implement `Unpin`

--- a/crates/rpl_patterns/src/errors.rs
+++ b/crates/rpl_patterns/src/errors.rs
@@ -249,3 +249,15 @@ pub struct UncheckedPtrOffset {
     #[label(rpl_patterns_offset_label)]
     pub offset: Span,
 }
+
+// for cve_2020_35901
+#[derive(Diagnostic)]
+#[diag(rpl_patterns_unsound_pin_project)]
+#[note]
+pub struct UnsoundPinProject<'tcx> {
+    #[primary_span]
+    pub span: Span,
+    #[label]
+    pub mut_self: Span,
+    pub ty: Ty<'tcx>,
+}

--- a/crates/rpl_patterns/src/inline/cve_2020_35901.rs
+++ b/crates/rpl_patterns/src/inline/cve_2020_35901.rs
@@ -1,0 +1,120 @@
+use rpl_context::PatCtxt;
+use rpl_mir::{pat, CheckMirCtxt};
+use rustc_hir::def_id::LocalDefId;
+use rustc_hir::intravisit::{self, Visitor};
+use rustc_hir::{self as hir};
+use rustc_middle::hir::nested_filter::All;
+use rustc_middle::ty::{self, Ty, TyCtxt};
+use rustc_span::{Span, Symbol};
+
+#[instrument(level = "info", skip_all)]
+pub fn check_item(tcx: TyCtxt<'_>, pcx: PatCtxt<'_>, item_id: hir::ItemId) {
+    let item = tcx.hir().item(item_id);
+    // let def_id = item_id.owner_id.def_id;
+    let mut check_ctxt = CheckFnCtxt::new(tcx, pcx);
+    check_ctxt.visit_item(item);
+}
+
+struct CheckFnCtxt<'pcx, 'tcx> {
+    tcx: TyCtxt<'tcx>,
+    pcx: PatCtxt<'pcx>,
+}
+
+impl<'pcx, 'tcx> CheckFnCtxt<'pcx, 'tcx> {
+    fn new(tcx: TyCtxt<'tcx>, pcx: PatCtxt<'pcx>) -> Self {
+        Self { tcx, pcx }
+    }
+}
+
+impl<'tcx> Visitor<'tcx> for CheckFnCtxt<'_, 'tcx> {
+    type NestedFilter = All;
+    fn nested_visit_map(&mut self) -> Self::Map {
+        self.tcx.hir()
+    }
+
+    #[instrument(level = "debug", skip_all, fields(?item.owner_id))]
+    fn visit_item(&mut self, item: &'tcx hir::Item<'tcx>) -> Self::Result {
+        match item.kind {
+            hir::ItemKind::Trait(hir::IsAuto::No, ..) | hir::ItemKind::Impl(_) | hir::ItemKind::Fn(..) => {},
+            _ => return,
+        }
+        intravisit::walk_item(self, item);
+    }
+
+    #[instrument(level = "info", skip_all, fields(?def_id))]
+    fn visit_fn(
+        &mut self,
+        kind: intravisit::FnKind<'tcx>,
+        decl: &'tcx hir::FnDecl<'tcx>,
+        body_id: hir::BodyId,
+        _span: Span,
+        def_id: LocalDefId,
+    ) -> Self::Result {
+        // let vis = self.tcx.local_visibility(def_id);
+        // FIXME: should check accesibility of trait methods
+        if self.tcx.is_mir_available(def_id)
+        // && (vis == ty::Visibility::Public || vis == ty::Visibility::Restricted(CRATE_DEF_ID))
+        {
+            let body = self.tcx.optimized_mir(def_id);
+
+            let pattern = pattern_pin_project(self.pcx);
+            for matches in CheckMirCtxt::new(self.tcx, self.pcx, body, pattern.pattern, pattern.fn_pat).check() {
+                let span = matches[pattern.pin_mut_struct].span_no_inline(body);
+                let mut_self = body.local_decls[matches[pattern.mut_self]].source_info.span;
+                let ty = matches[pattern.ty_var.idx];
+                debug!(?span, ?mut_self, ?ty);
+                self.tcx
+                    .dcx()
+                    .emit_err(crate::errors::UnsoundPinProject { span, mut_self, ty });
+            }
+        }
+        intravisit::walk_fn(self, kind, decl, body_id, def_id);
+    }
+}
+
+struct PatternPinProject<'pcx> {
+    pattern: &'pcx pat::Pattern<'pcx>,
+    fn_pat: &'pcx pat::Fn<'pcx>,
+    mut_self: pat::Local,
+    pin_mut_struct: pat::Location,
+    ty_var: pat::TyVar,
+}
+
+#[rpl_macros::pattern_def]
+fn pattern_pin_project(pcx: PatCtxt<'_>) -> PatternPinProject<'_> {
+    let ty_var;
+    let mut_self;
+    let pin_mut_struct;
+    #[allow(non_snake_case)]
+    let pattern = rpl! {
+        #[meta($S:ty)]
+        struct $SizedStream {
+            $field: $S,
+        }
+
+        #[meta(#[export(ty_var)] $S:ty = is_not_unpin)]
+        fn $pattern(..) -> _ = mir! {
+            #[export(mut_self)]
+            let $self: &mut $SizedStream;
+            #[export(pin_mut_struct)]
+            let mut $pin_mut_struct: std::pin::Pin<&mut $SizedStream> = std::pin::Pin::<_> { __pointer: copy $self };
+            let mut $mut_struct: &mut $SizedStream = copy ($pin_mut_struct.__pointer);
+            let $mut_field: &mut $S = &mut ((*$mut_struct).$field);
+            let mut $pin_mut_field: std::pin::Pin<&mut $S> = std::pin::Pin::<_> { __pointer: copy $mut_field };
+        }
+    };
+    let fn_pat = pattern.fns.get_fn_pat(Symbol::intern("pattern")).unwrap();
+
+    PatternPinProject {
+        pattern,
+        fn_pat,
+        mut_self,
+        pin_mut_struct,
+        ty_var,
+    }
+}
+
+#[instrument(level = "debug", skip(tcx), ret)]
+fn is_not_unpin<'tcx>(tcx: TyCtxt<'tcx>, param_env: ty::ParamEnv<'tcx>, ty: Ty<'tcx>) -> bool {
+    !ty.is_unpin(tcx, param_env)
+}

--- a/crates/rpl_patterns/src/inline/mod.rs
+++ b/crates/rpl_patterns/src/inline/mod.rs
@@ -9,6 +9,7 @@ pub(crate) mod cve_2020_35881;
 pub(crate) mod cve_2020_35888;
 pub(crate) mod cve_2020_35892_3;
 pub(crate) mod cve_2020_35898_9;
+pub(crate) mod cve_2020_35901;
 pub(crate) mod cve_2020_35907;
 pub(crate) mod cve_2021_25904;
 pub(crate) mod cve_2021_29941_2;

--- a/crates/rpl_patterns/src/lib.rs
+++ b/crates/rpl_patterns/src/lib.rs
@@ -50,6 +50,7 @@ static ALL_PATTERNS: &[fn(TyCtxt<'_>, PatCtxt<'_>, ItemId)] = &[
     inline::cve_2020_35888::check_item,
     inline::cve_2020_35892_3::check_item,
     inline::cve_2020_35898_9::check_item,
+    inline::cve_2020_35901::check_item,
     inline::cve_2020_35907::check_item,
     normal::cve_2021_25904::check_item,
     inline::cve_2021_25904::check_item,

--- a/tests/compile-test.rs
+++ b/tests/compile-test.rs
@@ -30,6 +30,7 @@ extern crate serde;
 extern crate serde_json;
 extern crate syn;
 // extern crate tokio;
+extern crate pin_project;
 
 mod test_utils;
 
@@ -56,6 +57,7 @@ static TEST_DEPENDENCIES: &[&str] = &[
     "thiserror",
     "tracing",
     // "tokio",
+    "pin_project",
 ];
 
 /// Produces a string with an `--extern` flag for all UI test crate

--- a/tests/ui/cve_2020_35901_2/cve_2020_35901.rs
+++ b/tests/ui/cve_2020_35901_2/cve_2020_35901.rs
@@ -1,0 +1,118 @@
+use std::marker::PhantomData;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+use std::{fmt, mem};
+
+extern crate futures;
+extern crate pin_project;
+
+use futures::{ready, Stream};
+use pin_project::pin_project;
+
+/// Type that provides this trait can be streamed to a peer.
+pub trait MessageBody {
+    fn size(&self) -> BodySize;
+    fn poll_next(&mut self, cx: &mut Context<'_>) -> Poll<Option<Result<Bytes, Error>>>;
+}
+
+#[derive(Debug, PartialEq, Copy, Clone)]
+/// Body size hint
+pub enum BodySize {
+    None,
+    Empty,
+    Sized(usize),
+    Sized64(u64),
+    Stream,
+}
+
+/// Type represent streaming body.
+/// Response does not contain `content-length` header and appropriate transfer encoding is used.
+#[pin_project]
+pub struct BodyStream<S, E> {
+    #[pin]
+    stream: S,
+    _t: PhantomData<E>,
+}
+
+impl<S, E> MessageBody for BodyStream<S, E>
+where
+    S: Stream<Item = Result<Bytes, E>>,
+    E: Into<Error>,
+{
+    fn size(&self) -> BodySize {
+        BodySize::Stream
+    }
+    /// Attempts to pull out the next value of the underlying [`Stream`].
+    ///
+    /// Empty values are skipped to prevent [`BodyStream`]'s transmission being
+    /// ended on a zero-length chunk, but rather proceed until the underlying
+    /// [`Stream`] ends.
+    // #[rpl::dump_mir(dump_cfg, dump_ddg)]
+    fn poll_next(&mut self, cx: &mut Context<'_>) -> Poll<Option<Result<Bytes, Error>>> {
+        let mut stream = unsafe { Pin::new_unchecked(self) }.project().stream;
+        //~^ ERROR: it is unsound to call `Pin::new_unchecked` on a mutable reference that can be freely moved
+        loop {
+            return Poll::Ready(match ready!(stream.as_mut().poll_next(cx)) {
+                Some(Ok(ref bytes)) if bytes.is_empty() => continue,
+                opt => opt.map(|res| res.map_err(Into::into)),
+            });
+        }
+    }
+}
+
+/// Type represent streaming body. This body implementation should be used
+/// if total size of stream is known. Data get sent as is without using transfer encoding.
+#[pin_project]
+pub struct SizedStream<S> {
+    size: u64,
+    #[pin]
+    // FIXME: when there are multiple candidates of an ADT pattern, the ADT matcher failes to
+    // match the second pattern because not all the patterns are checked recursively like
+    // the statement candidates or local candidates.
+    stream: S,
+}
+
+impl<S> SizedStream<S>
+where
+    S: Stream<Item = Result<Bytes, Error>>,
+{
+    pub fn new(size: u64, stream: S) -> Self {
+        SizedStream { size, stream }
+    }
+}
+
+impl<S> MessageBody for SizedStream<S>
+where
+    S: Stream<Item = Result<Bytes, Error>>,
+{
+    fn size(&self) -> BodySize {
+        BodySize::Sized64(self.size)
+    }
+    /// Attempts to pull out the next value of the underlying [`Stream`].
+    ///
+    /// Empty values are skipped to prevent [`SizedStream`]'s transmission being
+    /// ended on a zero-length chunk, but rather proceed until the underlying
+    /// [`Stream`] ends.
+    // #[rpl::dump_mir(dump_cfg, dump_ddg)]
+    fn poll_next(&mut self, cx: &mut Context<'_>) -> Poll<Option<Result<Bytes, Error>>> {
+        // FIXME: this should be an error
+        let mut stream = unsafe { Pin::new_unchecked(self) }.project().stream;
+        // ERROR: it is unsound to call `Pin::new_unchecked` on a mutable reference that can be freely moved
+        loop {
+            return Poll::Ready(match ready!(stream.as_mut().poll_next(cx)) {
+                Some(Ok(ref bytes)) if bytes.is_empty() => continue,
+                val => val,
+            });
+        }
+    }
+}
+
+pub struct Bytes;
+
+impl Bytes {
+    fn is_empty(&self) -> bool {
+        true
+    }
+}
+
+pub struct Error;

--- a/tests/ui/cve_2020_35901_2/cve_2020_35901.stderr
+++ b/tests/ui/cve_2020_35901_2/cve_2020_35901.stderr
@@ -1,0 +1,12 @@
+error: it is unsound to call `Pin::new_unchecked` on a mutable reference that can be freely moved
+  --> tests/ui/cve_2020_35901_2/cve_2020_35901.rs:52:35
+   |
+LL |     fn poll_next(&mut self, cx: &mut Context<'_>) -> Poll<Option<Result<Bytes, Error>>> {
+   |                  --------- mutable reference here
+LL |         let mut stream = unsafe { Pin::new_unchecked(self) }.project().stream;
+   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: type `S` doesn't implement `Unpin`
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/cve_2020_35901_2/cve_2020_35901_2.rs
+++ b/tests/ui/cve_2020_35901_2/cve_2020_35901_2.rs
@@ -1,5 +1,0 @@
-//@ ignore-on-host
-
-fn main() {
-    panic!("Todo.");
-}


### PR DESCRIPTION
Remained bug:
when there are multiple candidates of an ADT pattern, the ADT matcher fails to match the second pattern because not all the patterns are checked recursively like the statement candidates or local candidates.