### PR TITLE
Diagnostics as tool lints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1176,6 +1176,7 @@ name = "rpl_patterns"
 version = "0.1.0"
 dependencies = [
  "libc",
+ "pin-project",
  "rpl_context",
  "rpl_macros",
  "rpl_match",

--- a/crates/rpl_patterns/Cargo.toml
+++ b/crates/rpl_patterns/Cargo.toml
@@ -15,6 +15,7 @@ rpl_context.workspace = true
 
 [dev-dependencies]
 libc.workspace = true
+pin-project.workspace = true
 
 [features]
 

--- a/crates/rpl_patterns/messages.en.ftl
+++ b/crates/rpl_patterns/messages.en.ftl
@@ -13,6 +13,7 @@ rpl_patterns_use_after_drop = use a pointer from `{$ty}` after dropped
     .note = the `{$ty}` value is dropped here
 
 rpl_patterns_misordered_parameters = misordered parameters `len` and `cap` in `Vec::from_raw_parts`
+    .label = `Vec::from_raw_parts` called here
     .help = the correct order is `Vec::from_raw_parts(ptr, len, cap)`
 
 rpl_patterns_wrong_assumption_of_fat_pointer_layout = wrong assumption of fat pointer layout
@@ -29,6 +30,7 @@ rpl_patterns_lengthless_buffer_passed_to_extern_function = it is usually a bug t
     .label = the pointer is passed here
 
 rpl_patterns_wrong_assumption_of_layout_compatibility = wrong assumption of layout compatibility from `{$type_from}` to `{$type_to}`
+    .cast_to_label = casted to `{$type_to}` here
     .note  = casted from this
     .help  = it's not guaranteed by Rust standard library. See https://github.com/rust-lang/rust/pull/78802
 

--- a/crates/rpl_patterns/messages.en.ftl
+++ b/crates/rpl_patterns/messages.en.ftl
@@ -5,9 +5,11 @@ rpl_patterns_offset_by_one = pointer out of bound
     .suggestion = did you mean this
 
 rpl_patterns_unsound_slice_cast = it is unsound to cast any slice `&{$mutability}[{$ty}]` to a byte slice `&{$mutability}[u8]`
+    .cast_to_label = casted to a byte slice here
     .note = trying to cast from this value of `&{$mutability}[{$ty}]` type
 
 rpl_patterns_use_after_drop = use a pointer from `{$ty}` after dropped
+    .use_label = used here
     .note = the `{$ty}` value is dropped here
 
 rpl_patterns_misordered_parameters = misordered parameters `len` and `cap` in `Vec::from_raw_parts`

--- a/crates/rpl_patterns/messages.en.ftl
+++ b/crates/rpl_patterns/messages.en.ftl
@@ -44,8 +44,10 @@ rpl_patterns_vec_set_len_to_truncate = Use `Vec::set_len` to truncate the length
     .help = Consider using `Vec::truncate` instead
 
 rpl_patterns_trust_exact_size_iterator = it is unsound to trust return value of `std::iter::ExactSizeIterator::len` and pass it to an unsafe function like `std::vec::Vec::set_len`, which may leak uninitialized memory
+    .label = length used here in `{$fn_name}`
+    .note = `std::iter::ExactSizeIterator::len` may not be implemented correctly, and it should be used as a hint rather than a fact
     .len_label = `std::iter::ExactSizeIterator::len` used here
-    .help = incorrect implementation of `std::iter::ExactSizeIterator::len` must not cause safety issues
+    .help = incorrect implementation of `std::iter::ExactSizeIterator::len` must not cause safety issues, and consider using `std::iter::TrustedLen` instead if it's stabilized
 
 rpl_patterns_slice_from_raw_parts_uninitialized = it violates the precondition of `{$fn_name}` to create a slice from uninitialized data
     .slice_label = slice created here
@@ -59,7 +61,8 @@ rpl_patterns_set_len_uninitialized = it violates the precondition of `Vec::set_l
     .vec_label = `Vec` created here
     .help = before calling `set_len` to extend its length, make sure all elements are initialized, using such as `spare_capacity_mut` or `as_mut_ptr`
 
-rpl_patterns_get_mut_in_rc_unsafecell = Obtaining a mutable reference to the value wrapped by `Rc<UnsafeCell<$T>>` is unsound
+rpl_patterns_get_mut_in_rc_unsafecell = Obtaining a mutable reference to the value wrapped by `Rc<UnsafeCell<$T>>` may be unsound
+    .get_mut_label = `UnsafeCell::get_mut` called here
     .note = there will be multiple mutable references to the value at the same time
     .help = use `std::cell::RefCell` instead
 

--- a/crates/rpl_patterns/messages.en.ftl
+++ b/crates/rpl_patterns/messages.en.ftl
@@ -77,6 +77,7 @@ rpl_patterns_uninvalidated_slice_from_raw_parts = it is unsound to trust pointer
     .help = consider marking the function as unsafe
 
 rpl_patterns_unsound_cast_between_u64_and_atomic_u64 = it is unsound to cast between `u64` and `AtomicU64`
+    .cast_label = casted here
     .note = the alignment of `u64` is smaller than `AtomicU64` on many 32-bits platforms
     .src_label = u64 created here
 
@@ -99,7 +100,8 @@ rpl_patterns_deref_unchecked_ptr_offset = it is unsound to dereference a pointer
     .help = check whether it's in bound before dereferencing
 
 rpl_patterns_unsound_pin_project = it is unsound to call `Pin::new_unchecked` on a mutable reference that can be freely moved
-    .label = mutable reference passed into a public function here
+    .pin_label = `Pin::new_unchecked` called here
+    .ref_label = mutable reference passed into a public function here
     .note = type `{$ty}` doesn't implement `Unpin`
 
 rpl_patterns_unchecked_ptr_offset = it is an undefined behavior to offset a pointer using an unchecked integer

--- a/crates/rpl_patterns/messages.en.ftl
+++ b/crates/rpl_patterns/messages.en.ftl
@@ -31,10 +31,12 @@ rpl_patterns_wrong_assumption_of_layout_compatibility = wrong assumption of layo
     .help  = it's not guaranteed by Rust standard library. See https://github.com/rust-lang/rust/pull/78802
 
 rpl_patterns_vec_set_len_to_extend = Use `Vec::set_len` to extend the length of a `Vec`, potentially including uninitialized elements
-    .label = `Vec` created here
+    .set_len_label = `Vec::set_len` called here
+    .vec_label = `Vec` created here
     .note = make sure all elements are initialized before using them
 
 rpl_patterns_vec_set_len_to_truncate = Use `Vec::set_len` to truncate the length of a `Vec`
+    .set_len_label = `Vec::set_len` called here
     .help = Consider using `Vec::truncate` instead
 
 rpl_patterns_trust_exact_size_iterator = it is unsound to trust return value of `std::iter::ExactSizeIterator::len` and pass it to an unsafe function like `std::vec::Vec::set_len`, which may leak uninitialized memory
@@ -49,6 +51,7 @@ rpl_patterns_slice_from_raw_parts_uninitialized = it violates the precondition o
     .help        = See https://doc.rust-lang.org/std/slice/fn.{$fn_name}.html
 
 rpl_patterns_set_len_uninitialized = it violates the precondition of `Vec::set_len` to extend a `Vec`'s length without initializing its content in advance
+    .set_len_label = `Vec::set_len` called here
     .vec_label = `Vec` created here
     .help = before calling `set_len` to extend its length, make sure all elements are initialized, using such as `spare_capacity_mut` or `as_mut_ptr`
 

--- a/crates/rpl_patterns/messages.en.ftl
+++ b/crates/rpl_patterns/messages.en.ftl
@@ -67,11 +67,14 @@ rpl_patterns_get_mut_in_rc_unsafecell = Obtaining a mutable reference to the val
     .help = use `std::cell::RefCell` instead
 
 rpl_patterns_drop_uninit_value = Possibly dropping an uninitialized value
+    .drop_label = dropped here
+    .help = assigning to a dereferenced pointer will cause previous value to be dropped, and try using `ptr::write` instead
 
-rpl_patterns_from_raw_parts = it is unsound to trust pointers from passed-in iterators in a public safe function
+rpl_patterns_uninvalidated_slice_from_raw_parts = it is unsound to trust pointers from passed-in iterators in a public safe function
+    .src_label = source iterator found here
     .ptr_label = pointer created here
     .slice_label = used here to create a slice from the pointer
-    .help = please mark the function as unsafe
+    .help = consider marking the function as unsafe
 
 rpl_patterns_unsound_cast_between_u64_and_atomic_u64 = it is unsound to cast between `u64` and `AtomicU64`
     .note = the alignment of `u64` is smaller than `AtomicU64` on many 32-bits platforms
@@ -80,7 +83,8 @@ rpl_patterns_unsound_cast_between_u64_and_atomic_u64 = it is unsound to cast bet
 rpl_patterns_thread_local_static_ref = it is unsound to expose a `&'static {$ty}` from a thread-local where `{$ty}` is `Sync`
     .sync_help = `{$ty}` is `Sync` so that it can shared among threads
     .help = the thread local is destroyed after the thread has been destroyed, and the exposed `&'static {$ty}` may outlive the thread it is exposed to
-    .label = thread local used here
+    .fn_label = function returning `&'static {$ty}` here
+    .thread_local_label = thread local used here
     .ret_label = `&'static {$ty}` returned here
 
 rpl_patterns_deref_null_pointer = Dereference of a possibly null pointer

--- a/crates/rpl_patterns/src/errors.rs
+++ b/crates/rpl_patterns/src/errors.rs
@@ -177,22 +177,22 @@ pub struct GetMutInRcUnsafeCell {
 }
 
 // for cve_2020_35888
-#[derive(Diagnostic)]
+#[derive(LintDiagnostic)]
 #[diag(rpl_patterns_drop_uninit_value)]
 pub struct DropUninitValue {
-    #[primary_span]
+    #[label(rpl_patterns_drop_label)]
     pub drop: Span,
 }
 
 // for cve_2020_35907
-#[derive(Diagnostic)]
+#[derive(LintDiagnostic)]
 #[diag(rpl_patterns_thread_local_static_ref)]
 #[help(rpl_patterns_sync_help)]
 #[help]
 pub struct ThreadLocalStaticRef<'tcx> {
-    #[primary_span]
+    #[label(rpl_patterns_fn_label)]
     pub span: Span,
-    #[label]
+    #[label(rpl_patterns_thread_local_label)]
     pub thread_local: Span,
     #[label(rpl_patterns_ret_label)]
     pub ret: Span,
@@ -201,11 +201,11 @@ pub struct ThreadLocalStaticRef<'tcx> {
 
 // for cve_2021_25904
 // FIXME: add a span for `#[help]` containing the function header
-#[derive(Diagnostic)]
-#[diag(rpl_patterns_from_raw_parts)]
+#[derive(LintDiagnostic)]
+#[diag(rpl_patterns_uninvalidated_slice_from_raw_parts)]
 #[help]
 pub struct UnvalidatedSliceFromRawParts {
-    #[primary_span]
+    #[label(rpl_patterns_src_label)]
     pub src: Span,
     #[label(rpl_patterns_ptr_label)]
     pub ptr: Span,

--- a/crates/rpl_patterns/src/errors.rs
+++ b/crates/rpl_patterns/src/errors.rs
@@ -52,20 +52,19 @@ pub struct OffsetByOne {
 }
 
 // for cve_2018_21000
-#[derive(Diagnostic)]
+#[derive(LintDiagnostic)]
 #[diag(rpl_patterns_misordered_parameters)]
 pub struct MisorderedParameters {
     #[help]
-    #[primary_span]
+    #[label(rpl_patterns_label)]
     pub span: Span,
 }
 
 // for cve_2020_35881
-#[derive(Diagnostic)]
+#[derive(LintDiagnostic)]
 #[diag(rpl_patterns_wrong_assumption_of_fat_pointer_layout)]
 #[help]
 pub struct WrongAssumptionOfFatPointerLayout {
-    #[primary_span]
     #[label(rpl_patterns_ptr_transmute_label)]
     pub ptr_transmute: Span,
     #[label(rpl_patterns_get_data_ptr_label)]
@@ -92,11 +91,11 @@ pub struct LengthlessBufferPassedToExternFunction {
 }
 
 // for cve_2021_27376
-#[derive(Diagnostic)]
+#[derive(LintDiagnostic)]
 #[diag(rpl_patterns_wrong_assumption_of_layout_compatibility)]
 #[help]
 pub struct WrongAssumptionOfLayoutCompatibility {
-    #[primary_span]
+    #[label(rpl_patterns_cast_to_label)]
     pub cast_to: Span,
     #[note]
     pub cast_from: Span,

--- a/crates/rpl_patterns/src/errors.rs
+++ b/crates/rpl_patterns/src/errors.rs
@@ -134,33 +134,33 @@ pub struct SliceFromRawPartsUninitialized {
 
 // for cve_2018_20992
 // use `Vec::set_len` to extend the length of a `Vec` without initializing the new elements
-#[derive(Diagnostic)]
+#[derive(LintDiagnostic)]
 #[diag(rpl_patterns_vec_set_len_to_extend)]
 #[note]
 pub struct VecSetLenToExtend {
-    #[primary_span]
+    #[label(rpl_patterns_set_len_label)]
     pub set_len: Span,
-    #[label]
+    #[label(rpl_patterns_vec_label)]
     pub vec: Span,
 }
 
 // for cve_2018_20992
 // a workaround for without `#without!`
-#[derive(Diagnostic)]
+#[derive(LintDiagnostic)]
 // use `Vec::set_len` to truncate the length of a `Vec`
 #[diag(rpl_patterns_vec_set_len_to_truncate)]
 pub struct VecSetLenToTruncate {
-    #[primary_span]
+    #[label(rpl_patterns_set_len_label)]
     #[help]
     pub span: Span,
 }
 
 // for cve_2019_16138
-#[derive(Diagnostic)]
+#[derive(LintDiagnostic)]
 #[diag(rpl_patterns_set_len_uninitialized)]
 #[help]
 pub struct SetLenUninitialized {
-    #[primary_span]
+    #[label(rpl_patterns_set_len_label)]
     pub set_len: Span,
     #[label(rpl_patterns_vec_label)]
     pub vec: Span,

--- a/crates/rpl_patterns/src/errors.rs
+++ b/crates/rpl_patterns/src/errors.rs
@@ -104,22 +104,23 @@ pub struct WrongAssumptionOfLayoutCompatibility {
 }
 
 // for cve_2021_27376
-#[derive(Diagnostic)]
+#[derive(LintDiagnostic)]
 #[diag(rpl_patterns_trust_exact_size_iterator)]
 #[help]
 pub struct TrustExactSizeIterator {
-    #[primary_span]
+    #[label(rpl_patterns_label)]
     pub set_len: Span,
     #[label(rpl_patterns_len_label)]
     pub len: Span,
+    pub fn_name: &'static str,
 }
 
 // for cve_2021_27376
-#[derive(Diagnostic)]
+#[derive(LintDiagnostic)]
 #[diag(rpl_patterns_slice_from_raw_parts_uninitialized)]
 #[help]
 pub struct SliceFromRawPartsUninitialized {
-    #[primary_span]
+    #[label(rpl_patterns_slice_label)]
     pub slice: Span,
     #[label(rpl_patterns_len_label)]
     pub len: Span,
@@ -165,11 +166,11 @@ pub struct SetLenUninitialized {
 }
 
 // for cve_2020_35898_9
-#[derive(Diagnostic)]
+#[derive(LintDiagnostic)]
 #[diag(rpl_patterns_get_mut_in_rc_unsafecell)]
 #[help]
 pub struct GetMutInRcUnsafeCell {
-    #[primary_span]
+    #[label(rpl_patterns_get_mut_label)]
     #[note]
     #[help]
     pub get_mut: Span,

--- a/crates/rpl_patterns/src/errors.rs
+++ b/crates/rpl_patterns/src/errors.rs
@@ -1,5 +1,5 @@
 use rustc_errors::IntoDiagArg;
-use rustc_macros::{Diagnostic, LintDiagnostic};
+use rustc_macros::LintDiagnostic;
 use rustc_middle::ty::{self, Ty};
 use rustc_span::Span;
 
@@ -214,22 +214,21 @@ pub struct UnvalidatedSliceFromRawParts {
 }
 
 // for cve_2022_23639
-#[derive(Diagnostic)]
+#[derive(LintDiagnostic)]
 #[diag(rpl_patterns_unsound_cast_between_u64_and_atomic_u64)]
 #[note]
 pub struct UnsoundCastBetweenU64AndAtomicU64 {
-    #[primary_span]
+    #[label(rpl_patterns_cast_label)]
     pub transmute: Span,
     #[label(rpl_patterns_src_label)]
     pub src: Span,
 }
 
 // for cve_2020_35860
-#[derive(Diagnostic)]
+#[derive(LintDiagnostic)]
 #[diag(rpl_patterns_deref_null_pointer)]
 #[note]
 pub struct DerefNullPointer {
-    #[primary_span]
     #[label(rpl_patterns_deref_label)]
     pub deref: Span,
     #[label(rpl_patterns_ptr_label)]
@@ -237,11 +236,10 @@ pub struct DerefNullPointer {
 }
 
 // for cve_2020_35877
-#[derive(Diagnostic)]
+#[derive(LintDiagnostic)]
 #[diag(rpl_patterns_deref_unchecked_ptr_offset)]
 #[help]
 pub struct DerefUncheckedPtrOffset {
-    #[primary_span]
     #[label(rpl_patterns_reference_label)]
     pub reference: Span,
     #[label(rpl_patterns_ptr_label)]
@@ -251,13 +249,13 @@ pub struct DerefUncheckedPtrOffset {
 }
 
 // for cve_2020_35901
-#[derive(Diagnostic)]
+#[derive(LintDiagnostic)]
 #[diag(rpl_patterns_unsound_pin_project)]
 #[note]
 pub struct UnsoundPinNewUnchecked<'tcx> {
-    #[primary_span]
+    #[label(rpl_patterns_pin_label)]
     pub span: Span,
-    #[label]
+    #[label(rpl_patterns_ref_label)]
     pub mut_self: Span,
     pub ty: Ty<'tcx>,
 }

--- a/crates/rpl_patterns/src/errors.rs
+++ b/crates/rpl_patterns/src/errors.rs
@@ -17,31 +17,30 @@ impl IntoDiagArg for Mutability {
     }
 }
 
-#[derive(Diagnostic)]
+#[derive(LintDiagnostic)]
 #[diag(rpl_patterns_unsound_slice_cast)]
 pub struct UnsoundSliceCast<'tcx> {
     #[note]
     pub cast_from: Span,
-    #[primary_span]
+    #[label(rpl_patterns_cast_to_label)]
     pub cast_to: Span,
     pub ty: Ty<'tcx>,
     pub mutability: Mutability,
 }
 
-#[derive(Diagnostic)]
+#[derive(LintDiagnostic)]
 #[diag(rpl_patterns_use_after_drop)]
 pub struct UseAfterDrop<'tcx> {
     #[note]
     pub drop_span: Span,
-    #[primary_span]
+    #[label(rpl_patterns_use_label)]
     pub use_span: Span,
     pub ty: Ty<'tcx>,
 }
 
-#[derive(Diagnostic)]
+#[derive(LintDiagnostic)]
 #[diag(rpl_patterns_offset_by_one)]
 pub struct OffsetByOne {
-    #[primary_span]
     #[label(rpl_patterns_read_label)]
     pub read: Span,
     #[label(rpl_patterns_ptr_label)]

--- a/crates/rpl_patterns/src/inline/cve_2018_21000.rs
+++ b/crates/rpl_patterns/src/inline/cve_2018_21000.rs
@@ -9,6 +9,8 @@ pub mod u8_to_t {
 
     use rpl_mir::{pat, CheckMirCtxt};
 
+    use crate::lints::MISORDERED_PARAMETERS;
+
     #[instrument(level = "info", skip_all)]
     pub fn check_item(tcx: TyCtxt<'_>, pcx: PatCtxt<'_>, item_id: hir::ItemId) {
         let item = tcx.hir().item(item_id);
@@ -50,7 +52,12 @@ pub mod u8_to_t {
                 for matches in CheckMirCtxt::new(self.tcx, self.pcx, body, pattern.pattern, pattern.fn_pat).check() {
                     let span = matches[pattern.from_raw_parts].span_no_inline(body);
                     debug!(?span);
-                    self.tcx.dcx().emit_err(crate::errors::MisorderedParameters { span });
+                    self.tcx.emit_node_span_lint(
+                        MISORDERED_PARAMETERS,
+                        self.tcx.local_def_id_to_hir_id(def_id),
+                        span,
+                        crate::errors::MisorderedParameters { span },
+                    );
                 }
             }
         }
@@ -162,6 +169,8 @@ pub mod t_to_u8 {
 
     use rpl_mir::{pat, CheckMirCtxt};
 
+    use crate::lints::MISORDERED_PARAMETERS;
+
     #[instrument(level = "info", skip_all)]
     pub fn check_item(tcx: TyCtxt<'_>, pcx: PatCtxt<'_>, item_id: hir::ItemId) {
         let item = tcx.hir().item(item_id);
@@ -203,7 +212,13 @@ pub mod t_to_u8 {
                 for matches in CheckMirCtxt::new(self.tcx, self.pcx, body, pattern.pattern, pattern.fn_pat).check() {
                     let span = matches[pattern.from_raw_parts].span_no_inline(body);
                     debug!(?span);
-                    self.tcx.dcx().emit_err(crate::errors::MisorderedParameters { span });
+
+                    self.tcx.emit_node_span_lint(
+                        MISORDERED_PARAMETERS,
+                        self.tcx.local_def_id_to_hir_id(def_id),
+                        span,
+                        crate::errors::MisorderedParameters { span },
+                    );
                 }
             }
         }

--- a/crates/rpl_patterns/src/inline/cve_2019_16138.rs
+++ b/crates/rpl_patterns/src/inline/cve_2019_16138.rs
@@ -7,6 +7,8 @@ use rustc_middle::hir::nested_filter::All;
 use rustc_middle::ty::TyCtxt;
 use rustc_span::{Span, Symbol};
 
+use crate::lints::SET_LEN_UNINITIALIZED;
+
 #[instrument(level = "info", skip_all)]
 pub fn check_item(tcx: TyCtxt<'_>, pcx: PatCtxt<'_>, item_id: hir::ItemId) {
     let item = tcx.hir().item(item_id);
@@ -55,9 +57,12 @@ impl<'tcx> Visitor<'tcx> for CheckFnCtxt<'_, 'tcx> {
                 let vec = matches[pattern_cast.vec].span_no_inline(body);
                 let set_len = matches[pattern_cast.set_len].span_no_inline(body);
                 debug!(?vec, ?set_len);
-                self.tcx
-                    .dcx()
-                    .emit_err(crate::errors::SetLenUninitialized { vec, set_len });
+                self.tcx.emit_node_span_lint(
+                    SET_LEN_UNINITIALIZED,
+                    self.tcx.local_def_id_to_hir_id(def_id),
+                    set_len,
+                    crate::errors::SetLenUninitialized { vec, set_len },
+                );
             }
         }
         intravisit::walk_fn(self, kind, decl, body_id, def_id);

--- a/crates/rpl_patterns/src/inline/cve_2020_35877.rs
+++ b/crates/rpl_patterns/src/inline/cve_2020_35877.rs
@@ -1,4 +1,4 @@
-use crate::lints::UNCHECKED_POINTER_OFFSET;
+use crate::lints::{DEREF_UNCHECKED_PTR_OFFSET, UNCHECKED_POINTER_OFFSET};
 use rpl_context::PatCtxt;
 use rpl_mir::pat::Location;
 use rpl_mir::{pat, CheckMirCtxt, Matched};
@@ -67,9 +67,12 @@ impl<'tcx> Visitor<'tcx> for CheckFnCtxt<'_, 'tcx> {
                 let offset = matches[pattern.offset].span_no_inline(body);
                 let reference = matches[pattern.reference].span_no_inline(body);
                 debug!(?ptr, ?offset, ?reference);
-                self.tcx
-                    .dcx()
-                    .emit_err(crate::errors::DerefUncheckedPtrOffset { ptr, offset, reference });
+                self.tcx.emit_node_span_lint(
+                    DEREF_UNCHECKED_PTR_OFFSET,
+                    self.tcx.local_def_id_to_hir_id(def_id),
+                    reference,
+                    crate::errors::DerefUncheckedPtrOffset { reference, ptr, offset },
+                );
             }
 
             // The pattern means: there exists a pointer `ptr` and an offset `offset` such that `ptr` is

--- a/crates/rpl_patterns/src/inline/cve_2020_35881.rs
+++ b/crates/rpl_patterns/src/inline/cve_2020_35881.rs
@@ -10,6 +10,8 @@ pub mod const_const_Transmute_ver {
 
     use rpl_mir::{pat, CheckMirCtxt};
 
+    use crate::lints::WRONG_ASSUMPTION_OF_FAT_POINTER_LAYOUT;
+
     #[instrument(level = "info", skip_all)]
     pub fn check_item(tcx: TyCtxt<'_>, pcx: PatCtxt<'_>, item_id: hir::ItemId) {
         let item = tcx.hir().item(item_id);
@@ -52,12 +54,15 @@ pub mod const_const_Transmute_ver {
                 for matches in CheckMirCtxt::new(self.tcx, self.pcx, body, pattern.pattern, pattern.fn_pat).check() {
                     let ptr_transmute = matches[pattern.ptr_transmute].span_no_inline(body);
                     let data_ptr_get = matches[pattern.data_ptr_get].span_no_inline(body);
-                    self.tcx
-                        .dcx()
-                        .emit_err(crate::errors::WrongAssumptionOfFatPointerLayout {
+                    self.tcx.emit_node_span_lint(
+                        WRONG_ASSUMPTION_OF_FAT_POINTER_LAYOUT,
+                        self.tcx.local_def_id_to_hir_id(def_id),
+                        ptr_transmute,
+                        crate::errors::WrongAssumptionOfFatPointerLayout {
                             ptr_transmute,
                             data_ptr_get,
-                        });
+                        },
+                    );
                 }
             }
         }
@@ -114,6 +119,8 @@ pub mod mut_mut_Transmute_ver {
 
     use rpl_mir::{pat, CheckMirCtxt};
 
+    use crate::lints::WRONG_ASSUMPTION_OF_FAT_POINTER_LAYOUT;
+
     #[instrument(level = "info", skip_all)]
     pub fn check_item(tcx: TyCtxt<'_>, pcx: PatCtxt<'_>, item_id: hir::ItemId) {
         let item = tcx.hir().item(item_id);
@@ -156,12 +163,15 @@ pub mod mut_mut_Transmute_ver {
                 for matches in CheckMirCtxt::new(self.tcx, self.pcx, body, pattern.pattern, pattern.fn_pat).check() {
                     let ptr_transmute = matches[pattern.ptr_transmute].span_no_inline(body);
                     let data_ptr_get = matches[pattern.data_ptr_get].span_no_inline(body);
-                    self.tcx
-                        .dcx()
-                        .emit_err(crate::errors::WrongAssumptionOfFatPointerLayout {
+                    self.tcx.emit_node_span_lint(
+                        WRONG_ASSUMPTION_OF_FAT_POINTER_LAYOUT,
+                        self.tcx.local_def_id_to_hir_id(def_id),
+                        ptr_transmute,
+                        crate::errors::WrongAssumptionOfFatPointerLayout {
                             ptr_transmute,
                             data_ptr_get,
-                        });
+                        },
+                    );
                 }
             }
         }
@@ -219,6 +229,8 @@ pub mod mut_const_PtrToPtr_ver {
 
     use rpl_mir::{pat, CheckMirCtxt};
 
+    use crate::lints::WRONG_ASSUMPTION_OF_FAT_POINTER_LAYOUT;
+
     #[instrument(level = "info", skip_all)]
     pub fn check_item(tcx: TyCtxt<'_>, pcx: PatCtxt<'_>, item_id: hir::ItemId) {
         let item = tcx.hir().item(item_id);
@@ -261,12 +273,15 @@ pub mod mut_const_PtrToPtr_ver {
                 for matches in CheckMirCtxt::new(self.tcx, self.pcx, body, pattern.pattern, pattern.fn_pat).check() {
                     let ptr_transmute = matches[pattern.ptr_transmute].span_no_inline(body);
                     let data_ptr_get = matches[pattern.data_ptr_get].span_no_inline(body);
-                    self.tcx
-                        .dcx()
-                        .emit_err(crate::errors::WrongAssumptionOfFatPointerLayout {
+                    self.tcx.emit_node_span_lint(
+                        WRONG_ASSUMPTION_OF_FAT_POINTER_LAYOUT,
+                        self.tcx.local_def_id_to_hir_id(def_id),
+                        ptr_transmute,
+                        crate::errors::WrongAssumptionOfFatPointerLayout {
                             ptr_transmute,
                             data_ptr_get,
-                        });
+                        },
+                    );
                 }
             }
         }

--- a/crates/rpl_patterns/src/inline/cve_2020_35888.rs
+++ b/crates/rpl_patterns/src/inline/cve_2020_35888.rs
@@ -7,6 +7,8 @@ use rustc_middle::hir::nested_filter::All;
 use rustc_middle::ty::TyCtxt;
 use rustc_span::{Span, Symbol};
 
+use crate::lints::DROP_UNINIT_VALUE;
+
 #[instrument(level = "info", skip_all)]
 pub fn check_item(tcx: TyCtxt<'_>, pcx: PatCtxt<'_>, item_id: hir::ItemId) {
     let item = tcx.hir().item(item_id);
@@ -52,7 +54,12 @@ impl<'tcx> Visitor<'tcx> for CheckFnCtxt<'_, 'tcx> {
             for matches in CheckMirCtxt::new(self.tcx, self.pcx, body, pattern.pattern, pattern.fn_pat).check() {
                 let drop = matches[pattern.drop].span_no_inline(body);
                 debug!(?drop);
-                self.tcx.dcx().emit_err(crate::errors::DropUninitValue { drop });
+                self.tcx.emit_node_span_lint(
+                    DROP_UNINIT_VALUE,
+                    self.tcx.local_def_id_to_hir_id(def_id),
+                    drop,
+                    crate::errors::DropUninitValue { drop },
+                );
             }
         }
         intravisit::walk_fn(self, kind, decl, body_id, def_id);

--- a/crates/rpl_patterns/src/inline/cve_2020_35907.rs
+++ b/crates/rpl_patterns/src/inline/cve_2020_35907.rs
@@ -7,6 +7,8 @@ use rustc_middle::hir::nested_filter::All;
 use rustc_middle::ty::{self, Ty, TyCtxt, TypingMode};
 use rustc_span::{Span, Symbol};
 
+use crate::lints::THREAD_LOCAL_STATIC_REF;
+
 #[instrument(level = "info", skip_all)]
 pub fn check_item(tcx: TyCtxt<'_>, pcx: PatCtxt<'_>, item_id: hir::ItemId) {
     let item = tcx.hir().item(item_id);
@@ -63,12 +65,17 @@ impl<'tcx> Visitor<'tcx> for CheckFnCtxt<'_, 'tcx> {
                 let ty = matches[pattern.ty_var.idx];
                 debug!(?thread_local, ?ty);
                 let span = decl.output.span();
-                self.tcx.dcx().emit_err(crate::errors::ThreadLocalStaticRef {
+                self.tcx.emit_node_span_lint(
+                    THREAD_LOCAL_STATIC_REF,
+                    self.tcx.local_def_id_to_hir_id(def_id),
                     span,
-                    thread_local,
-                    ret,
-                    ty,
-                });
+                    crate::errors::ThreadLocalStaticRef {
+                        span,
+                        thread_local,
+                        ret,
+                        ty,
+                    },
+                );
             }
         }
         intravisit::walk_fn(self, kind, decl, body_id, def_id);

--- a/crates/rpl_patterns/src/lints.rs
+++ b/crates/rpl_patterns/src/lints.rs
@@ -229,6 +229,78 @@ declare_tool_lint! {
     /// However, it does not initialize the new elements, which can lead to undefined behavior.
     /// To avoid this, you should always use the `resize` method to initialize the new elements.
     pub rpl::SET_LEN_UNINITIALIZED,
-    Warn,
+    Deny,
     "detects calling `Vec::set_len` without initializing the new elements in advance"
+}
+
+declare_tool_lint! {
+    /// The `rpl::unsound_slice_cast` lint detects a slice cast that can lead to undefined behavior.
+    ///
+    /// ### Example
+    ///
+    /// ```rust
+    /// #![deny(rpl::unsound_slice_cast)]
+    /// use core::{mem::size_of, slice::from_raw_parts};
+    /// let v: Vec<usize> = vec![1, 2, 3];
+    /// let slice: &[usize] = v.as_slice();
+    /// let slice: &[u8] = from_raw_parts(slice.as_ptr() as *const u8, slice.len() * size_of::<usize>()); // undefined behavior
+    /// ```
+    ///
+    /// {{produces}}
+    ///
+    /// ### Explanation
+    ///
+    /// A reference to a slice must has suitable alignment and size for the type it points to.
+    pub rpl::UNSOUND_SLICE_CAST,
+    Deny,
+    "detects a slice cast that can lead to undefined behavior"
+}
+
+declare_tool_lint! {
+    /// The `rpl::use_after_drop` lint detects using a value after it has been dropped.
+    ///
+    /// ### Example
+    ///
+    /// ```rust
+    /// #![deny(rpl::use_after_drop)]
+    /// let x = Box::new(42);
+    /// let y = x.as_ptr();
+    /// drop(x);
+    /// unsafe {
+    ///   *y; // undefined behavior
+    /// }
+    /// ```
+    ///
+    /// {{produces}}
+    ///
+    /// ### Explanation
+    ///
+    /// Using a value after it has been dropped is undefined behavior.
+    pub rpl::USE_AFTER_DROP,
+    Deny,
+    "detects using a value after it has been dropped"
+}
+
+declare_tool_lint! {
+    /// The `rpl::offset_by_one` lint detects reading or writing a value at an offset outside the bounds of a buffer by one.
+    ///
+    /// ### Example
+    ///
+    /// ```rust
+    /// #![deny(rpl::offset_by_one)]
+    /// let mut v = vec![1, 2, 3];
+    /// let p = v.as_mut_ptr();
+    /// unsafe {
+    ///   *p.offset(3) = 4; // undefined behavior
+    /// }
+    /// ```
+    ///
+    /// {{produces}}
+    ///
+    /// ### Explanation
+    ///
+    /// Reading or writing a value at an offset outside the bounds of a buffer by one is undefined behavior.
+    pub rpl::OFFSET_BY_ONE,
+    Deny,
+    "detects reading or writing a value at an offset outside the bounds of a buffer by one"
 }

--- a/crates/rpl_patterns/src/lints.rs
+++ b/crates/rpl_patterns/src/lints.rs
@@ -570,6 +570,8 @@ declare_tool_lint! {
     /// ### Example
     ///
     /// ```rust
+    /// use std::ops::Deref;
+    ///
     /// struct CBox<T: ?Sized> {
     ///   pub ptr: *mut T, // `ptr` may be assigned to as it's public
     /// }
@@ -592,7 +594,7 @@ declare_tool_lint! {
     ///
     ///   fn deref(&self) -> &T {
     ///     unsafe {
-    ///       *self.ptr // undefined behavior
+    ///       &*self.ptr // undefined behavior
     ///     }
     ///   }
     /// }
@@ -637,6 +639,7 @@ declare_tool_lint! {
     /// ### Example
     ///
     /// ```rust
+    /// use std::pin::Pin;
     /// use pin_project::pin_project;
     ///
     /// #[pin_project]

--- a/crates/rpl_patterns/src/lints.rs
+++ b/crates/rpl_patterns/src/lints.rs
@@ -304,3 +304,75 @@ declare_tool_lint! {
     Deny,
     "detects reading or writing a value at an offset outside the bounds of a buffer by one"
 }
+
+declare_tool_lint! {
+    /// The `rpl::misordered_parameters` lint detects misordered parameters in a function call.
+    ///
+    /// ### Example
+    ///
+    /// ```rust
+    /// #![deny(rpl::misordered_parameters)]
+    /// let mut v = vec![1, 2, 3];
+    /// let ptr = v.as_mut_ptr();
+    /// let len = v.len();
+    /// let cap = v.capacity();
+    /// let v = unsafe {
+    ///   Vec::from_raw_parts(ptr, cap, len) // misordered parameters
+    /// };
+    /// ```
+    ///
+    /// {{produces}}
+    ///
+    /// ### Explanation
+    ///
+    /// Misordered parameters in a unsafe function call can lead to undefined behavior.
+    pub rpl::MISORDERED_PARAMETERS,
+    Deny,
+    "detects misordered parameters in a function call"
+}
+
+declare_tool_lint! {
+    /// The `rpl::wrong_assumption_of_fat_pointer_layout` lint detects casting a fat pointer to a thin pointer using `as` or `std::mem::transmute`.
+    ///
+    /// ### Example
+    ///
+    /// ```rust
+    /// #![deny(rpl::wrong_assumption_of_fat_pointer_layout)]
+    /// let p = &mut [1, 2, 3] as *mut [i32];
+    /// let p = p as *mut i32; // undefined behavior
+    /// ```
+    ///
+    /// {{produces}}
+    ///
+    /// ### Explanation
+    ///
+    /// It's not documented that the data pointer part of a fat pointer is always at the beginning of the fat pointer.
+    pub rpl::WRONG_ASSUMPTION_OF_FAT_POINTER_LAYOUT,
+    Deny,
+    "detects casting a fat pointer to a thin pointer using `as` or `std::mem::transmute`"
+}
+
+declare_tool_lint! {
+    /// The `rpl::wrong_assumption_of_layout_compatibility` lint detects a wrong assumption of layout compatibility.
+    ///
+    /// ### Example
+    ///
+    /// ```rust
+    /// #![deny(rpl::wrong_assumption_of_layout_compatibility)]
+    /// use core::net::{SocketAddrV4, Ipv4Addr};
+    /// use libc::sockaddr;
+    /// let socket = SocketAddrV4::new(Ipv4Addr::new(127, 0, 0, 1), 8080);
+    /// let p: *const sockaddr = &socket as *const SocketAddrV4 as *const sockaddr;
+    /// // p may not be a valid sockaddr pointer
+    /// ```
+    ///
+    /// {{produces}}
+    ///
+    /// ### Explanation
+    ///
+    /// The layout of `SocketAddrV4` and `sockaddr` may not be compatible.
+    /// See <https://github.com/rust-lang/rust/pull/78802> for more information.
+    pub rpl::WRONG_ASSUMPTION_OF_LAYOUT_COMPATIBILITY,
+    Deny,
+    "detects casting a fat pointer to a thin pointer using `as` or `std::mem::transmute`"
+}

--- a/crates/rpl_patterns/src/normal/cve_2018_21000.rs
+++ b/crates/rpl_patterns/src/normal/cve_2018_21000.rs
@@ -9,6 +9,8 @@ pub mod u8_to_t {
 
     use rpl_mir::{pat, CheckMirCtxt};
 
+    use crate::lints::MISORDERED_PARAMETERS;
+
     #[instrument(level = "info", skip_all)]
     pub fn check_item(tcx: TyCtxt<'_>, pcx: PatCtxt<'_>, item_id: hir::ItemId) {
         let item = tcx.hir().item(item_id);
@@ -50,7 +52,13 @@ pub mod u8_to_t {
                 for matches in CheckMirCtxt::new(self.tcx, self.pcx, body, pattern.pattern, pattern.fn_pat).check() {
                     let span = matches[pattern.from_raw_parts].span_no_inline(body);
                     debug!(?span);
-                    self.tcx.dcx().emit_err(crate::errors::MisorderedParameters { span });
+
+                    self.tcx.emit_node_span_lint(
+                        MISORDERED_PARAMETERS,
+                        self.tcx.local_def_id_to_hir_id(def_id),
+                        span,
+                        crate::errors::MisorderedParameters { span },
+                    );
                 }
             }
         }
@@ -110,6 +118,8 @@ pub mod t_to_u8 {
 
     use rpl_mir::{pat, CheckMirCtxt};
 
+    use crate::lints::MISORDERED_PARAMETERS;
+
     #[instrument(level = "info", skip_all)]
     pub fn check_item(tcx: TyCtxt<'_>, pcx: PatCtxt<'_>, item_id: hir::ItemId) {
         let item = tcx.hir().item(item_id);
@@ -151,7 +161,13 @@ pub mod t_to_u8 {
                 for matches in CheckMirCtxt::new(self.tcx, self.pcx, body, pattern.pattern, pattern.fn_pat).check() {
                     let span = matches[pattern.from_raw_parts].span_no_inline(body);
                     debug!(?span);
-                    self.tcx.dcx().emit_err(crate::errors::MisorderedParameters { span });
+
+                    self.tcx.emit_node_span_lint(
+                        MISORDERED_PARAMETERS,
+                        self.tcx.local_def_id_to_hir_id(def_id),
+                        span,
+                        crate::errors::MisorderedParameters { span },
+                    );
                 }
             }
         }

--- a/crates/rpl_patterns/src/normal/cve_2019_16138.rs
+++ b/crates/rpl_patterns/src/normal/cve_2019_16138.rs
@@ -7,6 +7,8 @@ use rustc_middle::hir::nested_filter::All;
 use rustc_middle::ty::TyCtxt;
 use rustc_span::{Span, Symbol};
 
+use crate::lints::SET_LEN_UNINITIALIZED;
+
 #[instrument(level = "info", skip_all)]
 pub fn check_item(tcx: TyCtxt<'_>, pcx: PatCtxt<'_>, item_id: hir::ItemId) {
     let item = tcx.hir().item(item_id);
@@ -53,9 +55,12 @@ impl<'tcx> Visitor<'tcx> for CheckFnCtxt<'_, 'tcx> {
                 let vec = matches[pattern.vec].span_no_inline(body);
                 let set_len = matches[pattern.set_len].span_no_inline(body);
                 debug!(?vec, ?set_len);
-                self.tcx
-                    .dcx()
-                    .emit_err(crate::errors::SetLenUninitialized { vec, set_len });
+                self.tcx.emit_node_span_lint(
+                    SET_LEN_UNINITIALIZED,
+                    self.tcx.local_def_id_to_hir_id(def_id),
+                    set_len,
+                    crate::errors::SetLenUninitialized { vec, set_len },
+                );
             }
         }
         intravisit::walk_fn(self, kind, decl, body_id, def_id);

--- a/crates/rpl_patterns/src/normal/cve_2021_27376.rs
+++ b/crates/rpl_patterns/src/normal/cve_2021_27376.rs
@@ -7,6 +7,8 @@ use rustc_middle::hir::nested_filter::All;
 use rustc_middle::ty::TyCtxt;
 use rustc_span::{Span, Symbol};
 
+use crate::lints::WRONG_ASSUMPTION_OF_LAYOUT_COMPATIBILITY;
+
 #[instrument(level = "info", skip_all)]
 pub fn check_item(tcx: TyCtxt<'_>, pcx: PatCtxt<'_>, item_id: hir::ItemId) {
     let item = tcx.hir().item(item_id);
@@ -53,28 +55,34 @@ impl<'tcx> Visitor<'tcx> for CheckFnCtxt<'_, 'tcx> {
                 let cast_from = matches[pattern.cast_from].span_no_inline(body);
                 let cast_to = matches[pattern.cast_to].span_no_inline(body);
                 debug!(?cast_from, ?cast_to);
-                self.tcx
-                    .dcx()
-                    .emit_err(crate::errors::WrongAssumptionOfLayoutCompatibility {
+                self.tcx.emit_node_span_lint(
+                    WRONG_ASSUMPTION_OF_LAYOUT_COMPATIBILITY,
+                    self.tcx.local_def_id_to_hir_id(def_id),
+                    cast_to,
+                    crate::errors::WrongAssumptionOfLayoutCompatibility {
                         cast_from,
                         cast_to,
                         type_from: pattern.type_from,
                         type_to: pattern.type_to,
-                    });
+                    },
+                );
             }
             let pattern = pattern_cast_socket_addr_v4(self.pcx);
             for matches in CheckMirCtxt::new(self.tcx, self.pcx, body, pattern.pattern, pattern.fn_pat).check() {
                 let cast_from = matches[pattern.cast_from].span_no_inline(body);
                 let cast_to = matches[pattern.cast_to].span_no_inline(body);
                 debug!(?cast_from, ?cast_to);
-                self.tcx
-                    .dcx()
-                    .emit_err(crate::errors::WrongAssumptionOfLayoutCompatibility {
+                self.tcx.emit_node_span_lint(
+                    WRONG_ASSUMPTION_OF_LAYOUT_COMPATIBILITY,
+                    self.tcx.local_def_id_to_hir_id(def_id),
+                    cast_to,
+                    crate::errors::WrongAssumptionOfLayoutCompatibility {
                         cast_from,
                         cast_to,
                         type_from: pattern.type_from,
                         type_to: pattern.type_to,
-                    });
+                    },
+                );
             }
         }
         intravisit::walk_fn(self, kind, decl, body_id, def_id);

--- a/crates/rpl_patterns/src/normal/cve_2021_29941_2.rs
+++ b/crates/rpl_patterns/src/normal/cve_2021_29941_2.rs
@@ -7,6 +7,8 @@ use rustc_middle::hir::nested_filter::All;
 use rustc_middle::ty::TyCtxt;
 use rustc_span::{Span, Symbol};
 
+use crate::lints::{SLICE_FROM_RAW_PARTS_UNINITIALIZED, TRUST_EXACT_SIZE_ITERATOR};
+
 #[instrument(level = "info", skip_all)]
 pub fn check_item(tcx: TyCtxt<'_>, pcx: PatCtxt<'_>, item_id: hir::ItemId) {
     let item = tcx.hir().item(item_id);
@@ -54,9 +56,16 @@ impl<'tcx> Visitor<'tcx> for CheckFnCtxt<'_, 'tcx> {
                 let set_len = matches[pattern.set_len].span_no_inline(body);
 
                 debug!(?len, ?set_len);
-                self.tcx
-                    .dcx()
-                    .emit_err(crate::errors::TrustExactSizeIterator { len, set_len });
+                self.tcx.emit_node_span_lint(
+                    TRUST_EXACT_SIZE_ITERATOR,
+                    self.tcx.local_def_id_to_hir_id(def_id),
+                    set_len,
+                    crate::errors::TrustExactSizeIterator {
+                        len,
+                        set_len,
+                        fn_name: "Vec::set_len",
+                    },
+                );
             }
 
             let pattern = pattern_uninitialized_slice(self.pcx);
@@ -67,13 +76,19 @@ impl<'tcx> Visitor<'tcx> for CheckFnCtxt<'_, 'tcx> {
                 let slice = matches[pattern.slice].span_no_inline(body);
 
                 debug!(?len, ?ptr, ?vec, ?slice);
-                self.tcx.dcx().emit_err(crate::errors::SliceFromRawPartsUninitialized {
-                    len,
-                    ptr,
-                    vec,
+
+                self.tcx.emit_node_span_lint(
+                    SLICE_FROM_RAW_PARTS_UNINITIALIZED,
+                    self.tcx.local_def_id_to_hir_id(def_id),
                     slice,
-                    fn_name: "std::slice::from_raw_parts",
-                });
+                    crate::errors::SliceFromRawPartsUninitialized {
+                        len,
+                        ptr,
+                        vec,
+                        slice,
+                        fn_name: "std::slice::from_raw_parts",
+                    },
+                );
             }
 
             let pattern = pattern_uninitialized_slice_mut(self.pcx);
@@ -84,13 +99,19 @@ impl<'tcx> Visitor<'tcx> for CheckFnCtxt<'_, 'tcx> {
                 let slice = matches[pattern.slice].span_no_inline(body);
 
                 debug!(?len, ?ptr, ?vec, ?slice);
-                self.tcx.dcx().emit_err(crate::errors::SliceFromRawPartsUninitialized {
-                    len,
-                    ptr,
-                    vec,
+
+                self.tcx.emit_node_span_lint(
+                    SLICE_FROM_RAW_PARTS_UNINITIALIZED,
+                    self.tcx.local_def_id_to_hir_id(def_id),
                     slice,
-                    fn_name: "std::slice::from_raw_parts_mut",
-                });
+                    crate::errors::SliceFromRawPartsUninitialized {
+                        len,
+                        ptr,
+                        vec,
+                        slice,
+                        fn_name: "std::slice::from_raw_parts_mut",
+                    },
+                );
             }
         }
         intravisit::walk_fn(self, kind, decl, body_id, def_id);

--- a/tests/ui/cve_2018_20992/cve_2018_20992.stderr
+++ b/tests/ui/cve_2018_20992/cve_2018_20992.stderr
@@ -2,13 +2,15 @@ error: Use `Vec::set_len` to truncate the length of a `Vec`
   --> tests/ui/cve_2018_20992/cve_2018_20992.rs:4:8
    |
 LL |     if buffer.len() < new_len {
-   |        ^^^^^^^^^^^^^^^^^^^^^^
+   |        ^^^^^^^^^^^^^^^^^^^^^^ `Vec::set_len` called here
    |
 help: Consider using `Vec::truncate` instead
   --> tests/ui/cve_2018_20992/cve_2018_20992.rs:4:8
    |
 LL |     if buffer.len() < new_len {
    |        ^^^^^^^^^^^^^^^^^^^^^^
+   = note: `-D rpl::set-len-to-truncate` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(rpl::set_len_to_truncate)]`
 
 error: Use `Vec::set_len` to extend the length of a `Vec`, potentially including uninitialized elements
   --> tests/ui/cve_2018_20992/cve_2018_20992.rs:10:20
@@ -17,9 +19,10 @@ LL | pub fn ensure_buffer_len(mut buffer: Vec<i32>, new_len: usize) -> Vec<i32> 
    |                          ---------- `Vec` created here
 ...
 LL |             buffer.set_len(new_len);
-   |                    ^^^^^^^^^^^^^^^^
+   |                    ^^^^^^^^^^^^^^^^ `Vec::set_len` called here
    |
    = note: make sure all elements are initialized before using them
+   = note: `#[deny(rpl::set_len_to_extend)]` on by default
 
 error: Use `Vec::set_len` to extend the length of a `Vec`, potentially including uninitialized elements
   --> tests/ui/cve_2018_20992/cve_2018_20992.rs:10:20
@@ -28,7 +31,7 @@ LL |             buffer = Vec::with_capacity(new_len);
    |             ------ `Vec` created here
 ...
 LL |             buffer.set_len(new_len);
-   |                    ^^^^^^^^^^^^^^^^
+   |                    ^^^^^^^^^^^^^^^^ `Vec::set_len` called here
    |
    = note: make sure all elements are initialized before using them
 
@@ -39,7 +42,7 @@ LL | pub fn ensure_buffer_len(mut buffer: Vec<i32>, new_len: usize) -> Vec<i32> 
    |                          ---------- `Vec` created here
 ...
 LL |         buffer.truncate(new_len);
-   |                ^^^^^^^^^^^^^^^^^
+   |                ^^^^^^^^^^^^^^^^^ `Vec::set_len` called here
    |
    = note: make sure all elements are initialized before using them
 

--- a/tests/ui/cve_2018_21000/cve_2018_21000.stderr
+++ b/tests/ui/cve_2018_21000/cve_2018_21000.stderr
@@ -2,19 +2,20 @@ error: misordered parameters `len` and `cap` in `Vec::from_raw_parts`
   --> tests/ui/cve_2018_21000/cve_2018_21000.rs:11:5
    |
 LL |     Vec::from_raw_parts(ptr as *mut T, capacity, len)
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `Vec::from_raw_parts` called here
    |
 help: the correct order is `Vec::from_raw_parts(ptr, len, cap)`
   --> tests/ui/cve_2018_21000/cve_2018_21000.rs:11:5
    |
 LL |     Vec::from_raw_parts(ptr as *mut T, capacity, len)
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: `#[deny(rpl::misordered_parameters)]` on by default
 
 error: misordered parameters `len` and `cap` in `Vec::from_raw_parts`
   --> tests/ui/cve_2018_21000/cve_2018_21000.rs:21:5
    |
 LL |     Vec::from_raw_parts(ptr as *mut u8, capacity, len)
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `Vec::from_raw_parts` called here
    |
 help: the correct order is `Vec::from_raw_parts(ptr, len, cap)`
   --> tests/ui/cve_2018_21000/cve_2018_21000.rs:21:5

--- a/tests/ui/cve_2019_15548/cve_2019_15548.stderr
+++ b/tests/ui/cve_2019_15548/cve_2019_15548.stderr
@@ -10,7 +10,7 @@ note: the `*const libc::c_char` is created here
    |
 LL |         let ret = ll::instr(mem::transmute(buf));
    |                             ^^^^^^^^^^^^^^^^^^^
-   = note: `#[deny(rust_string_pointer_as_c_string_pointer)]` on by default
+   = note: `#[deny(rpl::rust_string_pointer_as_c_string_pointer)]` on by default
 
 error: it is usually a bug to pass a buffer pointer to an extern function without specifying its length
   --> tests/ui/cve_2019_15548/cve_2019_15548.rs:18:29
@@ -18,8 +18,8 @@ error: it is usually a bug to pass a buffer pointer to an extern function withou
 LL |         let ret = ll::instr(mem::transmute(buf));
    |                             ^^^^^^^^^^^^^^^^^^^ the pointer is passed here
    |
-   = note: `-D lengthless-buffer-passed-to-extern-function` implied by `-D warnings`
-   = help: to override `-D warnings` add `#[allow(lengthless_buffer_passed_to_extern_function)]`
+   = note: `-D rpl::lengthless-buffer-passed-to-extern-function` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(rpl::lengthless_buffer_passed_to_extern_function)]`
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/cve_2019_15548/cve_2019_15548_not_inlined.stderr
+++ b/tests/ui/cve_2019_15548/cve_2019_15548_not_inlined.stderr
@@ -10,7 +10,7 @@ note: the `*const libc::c_char` is created here
    |
 LL |         let ret = ll::instr(mem::transmute(buf));
    |                             ^^^^^^^^^^^^^^^^^^^
-   = note: `#[deny(rust_string_pointer_as_c_string_pointer)]` on by default
+   = note: `#[deny(rpl::rust_string_pointer_as_c_string_pointer)]` on by default
 
 error: it is usually a bug to pass a buffer pointer to an extern function without specifying its length
   --> tests/ui/cve_2019_15548/cve_2019_15548_not_inlined.rs:20:29
@@ -18,8 +18,8 @@ error: it is usually a bug to pass a buffer pointer to an extern function withou
 LL |         let ret = ll::instr(mem::transmute(buf));
    |                             ^^^^^^^^^^^^^^^^^^^ the pointer is passed here
    |
-   = note: `-D lengthless-buffer-passed-to-extern-function` implied by `-D warnings`
-   = help: to override `-D warnings` add `#[allow(lengthless_buffer_passed_to_extern_function)]`
+   = note: `-D rpl::lengthless-buffer-passed-to-extern-function` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(rpl::lengthless_buffer_passed_to_extern_function)]`
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/cve_2019_16138/cve_2019_16138.stderr
+++ b/tests/ui/cve_2019_16138/cve_2019_16138.stderr
@@ -8,8 +8,7 @@ LL |         ret.set_len(pixel_count);
    |             ^^^^^^^^^^^^^^^^^^^^ `Vec::set_len` called here
    |
    = help: before calling `set_len` to extend its length, make sure all elements are initialized, using such as `spare_capacity_mut` or `as_mut_ptr`
-   = note: `-D rpl::set-len-uninitialized` implied by `-D warnings`
-   = help: to override `-D warnings` add `#[allow(rpl::set_len_uninitialized)]`
+   = note: `#[deny(rpl::set_len_uninitialized)]` on by default
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/cve_2019_16138/cve_2019_16138.stderr
+++ b/tests/ui/cve_2019_16138/cve_2019_16138.stderr
@@ -5,9 +5,11 @@ LL |     let mut ret: Vec<(u8, u8, u8)> = Vec::with_capacity(pixel_count);
    |                                      ------------------------------- `Vec` created here
 LL |     unsafe {
 LL |         ret.set_len(pixel_count);
-   |             ^^^^^^^^^^^^^^^^^^^^
+   |             ^^^^^^^^^^^^^^^^^^^^ `Vec::set_len` called here
    |
    = help: before calling `set_len` to extend its length, make sure all elements are initialized, using such as `spare_capacity_mut` or `as_mut_ptr`
+   = note: `-D rpl::set-len-uninitialized` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(rpl::set_len_uninitialized)]`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/cve_2019_16138/cve_2019_16138_not_inlined.stderr
+++ b/tests/ui/cve_2019_16138/cve_2019_16138_not_inlined.stderr
@@ -8,8 +8,7 @@ LL |         ret.set_len(pixel_count);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^ `Vec::set_len` called here
    |
    = help: before calling `set_len` to extend its length, make sure all elements are initialized, using such as `spare_capacity_mut` or `as_mut_ptr`
-   = note: `-D rpl::set-len-uninitialized` implied by `-D warnings`
-   = help: to override `-D warnings` add `#[allow(rpl::set_len_uninitialized)]`
+   = note: `#[deny(rpl::set_len_uninitialized)]` on by default
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/cve_2019_16138/cve_2019_16138_not_inlined.stderr
+++ b/tests/ui/cve_2019_16138/cve_2019_16138_not_inlined.stderr
@@ -5,9 +5,11 @@ LL |     let mut ret: Vec<(u8, u8, u8)> = Vec::with_capacity(pixel_count);
    |                                      ------------------------------- `Vec` created here
 LL |     unsafe {
 LL |         ret.set_len(pixel_count);
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^ `Vec::set_len` called here
    |
    = help: before calling `set_len` to extend its length, make sure all elements are initialized, using such as `spare_capacity_mut` or `as_mut_ptr`
+   = note: `-D rpl::set-len-uninitialized` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(rpl::set_len_uninitialized)]`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/cve_2019_16138/src/lib.stderr
+++ b/tests/ui/cve_2019_16138/src/lib.stderr
@@ -5,9 +5,10 @@ LL |                 let mut ret = Vec::with_capacity(pixel_count);
    |                               ------------------------------- `Vec` created here
 ...
 LL |                     ret.set_len(pixel_count);
-   |                         ^^^^^^^^^^^^^^^^^^^^
+   |                         ^^^^^^^^^^^^^^^^^^^^ `Vec::set_len` called here
    |
    = note: make sure all elements are initialized before using them
+   = note: `#[deny(rpl::set_len_to_extend)]` on by default
 
 error: it violates the precondition of `Vec::set_len` to extend a `Vec`'s length without initializing its content in advance
   --> tests/ui/cve_2019_16138/src/lib.rs:200:25
@@ -16,9 +17,11 @@ LL |                 let mut ret = Vec::with_capacity(pixel_count);
    |                               ------------------------------- `Vec` created here
 ...
 LL |                     ret.set_len(pixel_count);
-   |                         ^^^^^^^^^^^^^^^^^^^^
+   |                         ^^^^^^^^^^^^^^^^^^^^ `Vec::set_len` called here
    |
    = help: before calling `set_len` to extend its length, make sure all elements are initialized, using such as `spare_capacity_mut` or `as_mut_ptr`
+   = note: `-D rpl::set-len-uninitialized` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(rpl::set_len_uninitialized)]`
 
 error: it violates the precondition of `Vec::set_len` to extend a `Vec`'s length without initializing its content in advance
   --> tests/ui/cve_2019_16138/src/lib.rs:215:37
@@ -27,7 +30,7 @@ LL | ...                   let mut buf = Vec::<RGBE8Pixel>::with_capacity(uszwid
    |                                     ------------------------------------------ `Vec` created here
 LL | ...                   unsafe {
 LL | ...                       buf.set_len(uszwidth);
-   |                               ^^^^^^^^^^^^^^^^^
+   |                               ^^^^^^^^^^^^^^^^^ `Vec::set_len` called here
    |
    = help: before calling `set_len` to extend its length, make sure all elements are initialized, using such as `spare_capacity_mut` or `as_mut_ptr`
 

--- a/tests/ui/cve_2019_16138/src/lib.stderr
+++ b/tests/ui/cve_2019_16138/src/lib.stderr
@@ -42,10 +42,12 @@ LL |                 let mut ret = Vec::with_capacity(pixel_count);
 LL |                     let chunks_iter = ret.chunks_mut(uszwidth);
    |                                       ^^^^^^^^^^^^^^^^^^^^^^^^
    |                                       |
+   |                                       slice created here
    |                                       slice created with this length
    |                                       slice created with this pointer
    |
    = help: See https://doc.rust-lang.org/std/slice/fn.std::slice::from_raw_parts_mut.html
+   = note: `#[deny(rpl::slice_from_raw_parts_uninitialized)]` on by default
 
 error: it violates the precondition of `std::slice::from_raw_parts_mut` to create a slice from uninitialized data
   --> tests/ui/cve_2019_16138/src/lib.rs:218:65
@@ -56,6 +58,7 @@ LL | ...                   let mut buf = Vec::<RGBE8Pixel>::with_capacity(uszwid
 LL | ...                   (read_scanline(&mut self.r, &mut buf[..]))?;
    |                                                           ^^^^
    |                                                           |
+   |                                                           slice created here
    |                                                           slice created with this length
    |                                                           slice created with this pointer
    |

--- a/tests/ui/cve_2019_16138/src/lib.stderr
+++ b/tests/ui/cve_2019_16138/src/lib.stderr
@@ -20,8 +20,7 @@ LL |                     ret.set_len(pixel_count);
    |                         ^^^^^^^^^^^^^^^^^^^^ `Vec::set_len` called here
    |
    = help: before calling `set_len` to extend its length, make sure all elements are initialized, using such as `spare_capacity_mut` or `as_mut_ptr`
-   = note: `-D rpl::set-len-uninitialized` implied by `-D warnings`
-   = help: to override `-D warnings` add `#[allow(rpl::set_len_uninitialized)]`
+   = note: `#[deny(rpl::set_len_uninitialized)]` on by default
 
 error: it violates the precondition of `Vec::set_len` to extend a `Vec`'s length without initializing its content in advance
   --> tests/ui/cve_2019_16138/src/lib.rs:215:37

--- a/tests/ui/cve_2019_16138/src/lib_not_inlined.stderr
+++ b/tests/ui/cve_2019_16138/src/lib_not_inlined.stderr
@@ -5,9 +5,11 @@ LL |                 let mut ret = Vec::with_capacity(pixel_count);
    |                               ------------------------------- `Vec` created here
 ...
 LL |                     ret.set_len(pixel_count);
-   |                     ^^^^^^^^^^^^^^^^^^^^^^^^
+   |                     ^^^^^^^^^^^^^^^^^^^^^^^^ `Vec::set_len` called here
    |
    = help: before calling `set_len` to extend its length, make sure all elements are initialized, using such as `spare_capacity_mut` or `as_mut_ptr`
+   = note: `-D rpl::set-len-uninitialized` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(rpl::set_len_uninitialized)]`
 
 error: it violates the precondition of `Vec::set_len` to extend a `Vec`'s length without initializing its content in advance
   --> tests/ui/cve_2019_16138/src/lib_not_inlined.rs:213:33
@@ -16,7 +18,7 @@ LL | ...                   let mut buf = Vec::<RGBE8Pixel>::with_capacity(uszwid
    |                                     ------------------------------------------ `Vec` created here
 LL | ...                   unsafe {
 LL | ...                       buf.set_len(uszwidth);
-   |                           ^^^^^^^^^^^^^^^^^^^^^
+   |                           ^^^^^^^^^^^^^^^^^^^^^ `Vec::set_len` called here
    |
    = help: before calling `set_len` to extend its length, make sure all elements are initialized, using such as `spare_capacity_mut` or `as_mut_ptr`
 

--- a/tests/ui/cve_2019_16138/src/lib_not_inlined.stderr
+++ b/tests/ui/cve_2019_16138/src/lib_not_inlined.stderr
@@ -8,8 +8,7 @@ LL |                     ret.set_len(pixel_count);
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^ `Vec::set_len` called here
    |
    = help: before calling `set_len` to extend its length, make sure all elements are initialized, using such as `spare_capacity_mut` or `as_mut_ptr`
-   = note: `-D rpl::set-len-uninitialized` implied by `-D warnings`
-   = help: to override `-D warnings` add `#[allow(rpl::set_len_uninitialized)]`
+   = note: `#[deny(rpl::set_len_uninitialized)]` on by default
 
 error: it violates the precondition of `Vec::set_len` to extend a `Vec`'s length without initializing its content in advance
   --> tests/ui/cve_2019_16138/src/lib_not_inlined.rs:213:33

--- a/tests/ui/cve_2020_25016/cve_2020_25016.rs
+++ b/tests/ui/cve_2020_25016/cve_2020_25016.rs
@@ -21,6 +21,7 @@ where
         unsafe {
             core::slice::from_raw_parts(
                 //~^ ERROR: it is unsound to cast any slice `&[T]` to a byte slice `&[u8]`
+                //~| NOTE: `#[deny(rpl::unsound_slice_cast)]` on by default
                 slice.as_ptr() as *const _,
                 slice.len() * core::mem::size_of::<T>(),
             )

--- a/tests/ui/cve_2020_25016/cve_2020_25016.stderr
+++ b/tests/ui/cve_2020_25016/cve_2020_25016.stderr
@@ -3,29 +3,31 @@ error: it is unsound to cast any slice `&[T]` to a byte slice `&[u8]`
    |
 LL | /             core::slice::from_raw_parts(
 LL | |
+LL | |
 LL | |                 slice.as_ptr() as *const _,
 LL | |                 slice.len() * core::mem::size_of::<T>(),
 LL | |             )
-   | |_____________^
+   | |_____________^ casted to a byte slice here
    |
 note: trying to cast from this value of `&[T]` type
   --> tests/ui/cve_2020_25016/cve_2020_25016.rs:19:21
    |
 LL |         let slice = self.as_slice();
    |                     ^^^^^^^^^^^^^^^
+   = note: `#[deny(rpl::unsound_slice_cast)]` on by default
 
 error: it is unsound to cast any slice `&mut [T]` to a byte slice `&mut [u8]`
-  --> tests/ui/cve_2020_25016/cve_2020_25016.rs:35:13
+  --> tests/ui/cve_2020_25016/cve_2020_25016.rs:36:13
    |
 LL | /             core::slice::from_raw_parts_mut(
 LL | |
 LL | |                 slice.as_mut_ptr() as *mut _,
 LL | |                 slice.len() * core::mem::size_of::<T>(),
 LL | |             )
-   | |_____________^
+   | |_____________^ casted to a byte slice here
    |
 note: trying to cast from this value of `&mut [T]` type
-  --> tests/ui/cve_2020_25016/cve_2020_25016.rs:32:21
+  --> tests/ui/cve_2020_25016/cve_2020_25016.rs:33:21
    |
 LL |         let slice = self.as_mut_slice();
    |                     ^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/cve_2020_35860/cve_2020_35860.stderr
+++ b/tests/ui/cve_2020_35860/cve_2020_35860.stderr
@@ -8,6 +8,7 @@ LL |             let text = CStr::from_ptr(self.ptr);
    |                        dereference here
    |
    = note: this is because the pointer may be null
+   = note: `#[deny(rpl::deref_null_pointer)]` on by default
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/cve_2020_35873/cve_2020_35873.rs
+++ b/tests/ui/cve_2020_35873/cve_2020_35873.rs
@@ -31,6 +31,7 @@ impl Session<'_> {
         };
         unsafe { check!(ffi::sqlite3session_attach(self.sess, table)) };
         //~^ ERROR: use a pointer from `std::ffi::CString` after dropped
+        //~| NOTE: `#[deny(rpl::use_after_drop)]` on by default
         Ok(())
     }
 }

--- a/tests/ui/cve_2020_35873/cve_2020_35873.stderr
+++ b/tests/ui/cve_2020_35873/cve_2020_35873.stderr
@@ -2,13 +2,14 @@ error: use a pointer from `std::ffi::CString` after dropped
   --> tests/ui/cve_2020_35873/cve_2020_35873.rs:32:25
    |
 LL |         unsafe { check!(ffi::sqlite3session_attach(self.sess, table)) };
-   |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ used here
    |
 note: the `std::ffi::CString` value is dropped here
   --> tests/ui/cve_2020_35873/cve_2020_35873.rs:28:9
    |
 LL |         } else {
    |         ^
+   = note: `#[deny(rpl::use_after_drop)]` on by default
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/cve_2020_35877/cve_2020_35877.stderr
+++ b/tests/ui/cve_2020_35877/cve_2020_35877.stderr
@@ -11,6 +11,7 @@ LL |             &*p
    |             ^^^ dereferenced here
    |
    = help: check whether it's in bound before dereferencing
+   = note: `#[deny(rpl::deref_unchecked_ptr_offset)]` on by default
 
 error: it is unsound to dereference a pointer that is offset using an unchecked integer
   --> tests/ui/cve_2020_35877/cve_2020_35877.rs:49:13

--- a/tests/ui/cve_2020_35877/cve_2020_35877.stderr
+++ b/tests/ui/cve_2020_35877/cve_2020_35877.stderr
@@ -36,7 +36,7 @@ LL |                 p = p.offset(1);
    |
    = help: check whether it's in bound before offsetting
    = note: See the safety section in https://doc.rust-lang.org/std/primitive.pointer.html#method.offset
-   = note: `#[deny(unchecked_pointer_offset)]` on by default
+   = note: `#[deny(rpl::unchecked_pointer_offset)]` on by default
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/cve_2020_35877/minimal.stderr
+++ b/tests/ui/cve_2020_35877/minimal.stderr
@@ -8,7 +8,7 @@ LL |         p = p.add(index);
    |
    = help: check whether it's in bound before offsetting
    = note: See the safety section in https://doc.rust-lang.org/std/primitive.pointer.html#method.offset
-   = note: `#[deny(unchecked_pointer_offset)]` on by default
+   = note: `#[deny(rpl::unchecked_pointer_offset)]` on by default
 
 error: it is an undefined behavior to offset a pointer using an unchecked integer
   --> tests/ui/cve_2020_35877/minimal.rs:14:15

--- a/tests/ui/cve_2020_35881/cve_2020_35881.stderr
+++ b/tests/ui/cve_2020_35881/cve_2020_35881.stderr
@@ -8,6 +8,7 @@ LL |     *mem::transmute::<*const *const T, *const *const ()>(&val)
    |     try to get data ptr from first 8 bytes here
    |
    = help: the Rust Compiler does not expose the layout of fat pointers
+   = note: `#[deny(rpl::wrong_assumption_of_fat_pointer_layout)]` on by default
 
 error: wrong assumption of fat pointer layout
   --> tests/ui/cve_2020_35881/cve_2020_35881.rs:9:6

--- a/tests/ui/cve_2020_35881_dyn_derive/dyn_derive.stderr
+++ b/tests/ui/cve_2020_35881_dyn_derive/dyn_derive.stderr
@@ -8,6 +8,7 @@ LL |             *data_ptr = f(self);
    |                         ------- try to get data ptr from first 8 bytes here
    |
    = help: the Rust Compiler does not expose the layout of fat pointers
+   = note: `#[deny(rpl::wrong_assumption_of_fat_pointer_layout)]` on by default
 
 error: wrong assumption of fat pointer layout
   --> tests/ui/cve_2020_35881_dyn_derive/dyn_derive.rs:14:24

--- a/tests/ui/cve_2020_35888/cve_2020_35888.stderr
+++ b/tests/ui/cve_2020_35888/cve_2020_35888.stderr
@@ -2,7 +2,9 @@ error: Possibly dropping an uninitialized value
   --> tests/ui/cve_2020_35888/cve_2020_35888.rs:18:17
    |
 LL |                 (*(ptr.wrapping_offset(i as isize))) = template.clone();
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ dropped here
+   |
+   = note: `#[deny(rpl::drop_uninit_value)]` on by default
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/cve_2020_35888_simplified/cve_2020_35888_simplified.stderr
+++ b/tests/ui/cve_2020_35888_simplified/cve_2020_35888_simplified.stderr
@@ -2,7 +2,9 @@ error: Possibly dropping an uninitialized value
   --> tests/ui/cve_2020_35888_simplified/cve_2020_35888_simplified.rs:18:9
    |
 LL |         (*ptr) = DropDetector(12345);
-   |         ^^^^^^
+   |         ^^^^^^ dropped here
+   |
+   = note: `#[deny(rpl::drop_uninit_value)]` on by default
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/cve_2020_35892_3/cve_2020_35892_3.stderr
+++ b/tests/ui/cve_2020_35892_3/cve_2020_35892_3.stderr
@@ -15,6 +15,7 @@ help: this is because `self.len` exceeds the container's length by one
    |
 LL |             last_elem_ptr = self.mem.offset(self.len as isize);
    |                                             ^^^^^^^^
+   = note: `#[deny(rpl::offset_by_one)]` on by default
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/cve_2020_35898_9/cve_2020_35898_9.rs
+++ b/tests/ui/cve_2020_35898_9/cve_2020_35898_9.rs
@@ -16,6 +16,6 @@ pub struct Cell<T> {
 impl<T> Cell<T> {
     pub fn get_mut(&mut self) -> &mut T {
         unsafe { &mut *self.inner.as_ref().get() }
-                //~^ ERROR: Obtaining a mutable reference to the value wrapped by `Rc<UnsafeCell<$T>>` is unsound
+        //~^ ERROR: Obtaining a mutable reference to the value wrapped by `Rc<UnsafeCell<$T>>` may be unsound
     }
 }

--- a/tests/ui/cve_2020_35898_9/cve_2020_35898_9.stderr
+++ b/tests/ui/cve_2020_35898_9/cve_2020_35898_9.stderr
@@ -1,8 +1,8 @@
-error: Obtaining a mutable reference to the value wrapped by `Rc<UnsafeCell<$T>>` is unsound
+error: Obtaining a mutable reference to the value wrapped by `Rc<UnsafeCell<$T>>` may be unsound
   --> tests/ui/cve_2020_35898_9/cve_2020_35898_9.rs:18:18
    |
 LL |         unsafe { &mut *self.inner.as_ref().get() }
-   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `UnsafeCell::get_mut` called here
    |
    = help: use `std::cell::RefCell` instead
 note: there will be multiple mutable references to the value at the same time
@@ -15,6 +15,7 @@ help: use `std::cell::RefCell` instead
    |
 LL |         unsafe { &mut *self.inner.as_ref().get() }
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: `#[deny(rpl::get_mut_in_rc_unsafecell)]` on by default
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/cve_2020_35901_2/cve_2020_35901.stderr
+++ b/tests/ui/cve_2020_35901_2/cve_2020_35901.stderr
@@ -4,9 +4,10 @@ error: it is unsound to call `Pin::new_unchecked` on a mutable reference that ca
 LL |     fn poll_next(&mut self, cx: &mut Context<'_>) -> Poll<Option<Result<Bytes, Error>>> {
    |                  --------- mutable reference passed into a public function here
 LL |         let mut stream = unsafe { Pin::new_unchecked(self) }.project().stream;
-   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^ `Pin::new_unchecked` called here
    |
    = note: type `S` doesn't implement `Unpin`
+   = note: `#[deny(rpl::unsound_pin_project)]` on by default
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/cve_2020_35901_2/cve_2020_35902.stderr
+++ b/tests/ui/cve_2020_35901_2/cve_2020_35902.stderr
@@ -5,9 +5,10 @@ LL |     pub fn flush(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), U::Err
    |                  --------- mutable reference passed into a public function here
 ...
 LL |                 Pin::new_unchecked(&mut self.io).poll_write(cx, &self.write_buf)
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `Pin::new_unchecked` called here
    |
    = note: type `T` doesn't implement `Unpin`
+   = note: `#[deny(rpl::unsound_pin_project)]` on by default
 
 error: it is unsound to call `Pin::new_unchecked` on a mutable reference that can be freely moved
   --> tests/ui/cve_2020_35901_2/cve_2020_35902.rs:136:25
@@ -16,7 +17,7 @@ LL |     pub fn flush(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), U::Err
    |                  --------- mutable reference passed into a public function here
 ...
 LL |         ready!(unsafe { Pin::new_unchecked(&mut self.io).poll_flush(cx) })?;
-   |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `Pin::new_unchecked` called here
    |
    = note: type `T` doesn't implement `Unpin`
 
@@ -27,7 +28,7 @@ LL |     pub fn close(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), U::Err
    |                  --------- mutable reference passed into a public function here
 ...
 LL |             ready!(Pin::new_unchecked(&mut self.io).poll_flush(cx))?;
-   |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `Pin::new_unchecked` called here
    |
    = note: type `T` doesn't implement `Unpin`
 
@@ -38,7 +39,7 @@ LL |     pub fn close(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), U::Err
    |                  --------- mutable reference passed into a public function here
 ...
 LL |             ready!(Pin::new_unchecked(&mut self.io).poll_shutdown(cx))?;
-   |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `Pin::new_unchecked` called here
    |
    = note: type `T` doesn't implement `Unpin`
 

--- a/tests/ui/cve_2020_35907/cve_2020_35907.stderr
+++ b/tests/ui/cve_2020_35907/cve_2020_35907.stderr
@@ -2,7 +2,7 @@ error: it is unsound to expose a `&'static std::task::Waker` from a thread-local
   --> tests/ui/cve_2020_35907/cve_2020_35907.rs:21:28
    |
 LL | pub fn noop_waker_ref() -> &'static Waker {
-   |                            ^^^^^^^^^^^^^^
+   |                            ^^^^^^^^^^^^^^ function returning `&'static std::task::Waker` here
 ...
 LL |     NOOP_WAKER_INSTANCE.with(|l| unsafe { &*l.get() })
    |     --------------------------------------------------
@@ -12,6 +12,7 @@ LL |     NOOP_WAKER_INSTANCE.with(|l| unsafe { &*l.get() })
    |
    = help: `std::task::Waker` is `Sync` so that it can shared among threads
    = help: the thread local is destroyed after the thread has been destroyed, and the exposed `&'static std::task::Waker` may outlive the thread it is exposed to
+   = note: `#[deny(rpl::thread_local_static_ref)]` on by default
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/cve_2021_25904/cve_2021_25904.stderr
+++ b/tests/ui/cve_2021_25904/cve_2021_25904.stderr
@@ -2,7 +2,7 @@ error: it is unsound to trust pointers from passed-in iterators in a public safe
   --> tests/ui/cve_2021_25904/cve_2021_25904.rs:439:50
    |
 LL |     pub fn copy_from_raw_parts<I, IU>(&mut self, mut src: I, mut src_linesize: IU)
-   |                                                  ^^^^^^^
+   |                                                  ^^^^^^^ source iterator found here
 ...
 LL |                 let rr = src.next().unwrap();
    |                                     -------- pointer created here
@@ -10,7 +10,8 @@ LL |                 let rr = src.next().unwrap();
 LL |                 let ss = unsafe { slice::from_raw_parts(rr, hb * s_linesize) };
    |                                   ------------------------------------------ used here to create a slice from the pointer
    |
-   = help: please mark the function as unsafe
+   = help: consider marking the function as unsafe
+   = note: `#[deny(rpl::unvalidated_slice_from_raw_parts)]` on by default
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/cve_2021_25904/cve_2021_25904_not_inlined.stderr
+++ b/tests/ui/cve_2021_25904/cve_2021_25904_not_inlined.stderr
@@ -2,7 +2,7 @@ error: it is unsound to trust pointers from passed-in iterators in a public safe
   --> tests/ui/cve_2021_25904/cve_2021_25904_not_inlined.rs:441:50
    |
 LL |     pub fn copy_from_raw_parts<I, IU>(&mut self, mut src: I, mut src_linesize: IU)
-   |                                                  ^^^^^^^
+   |                                                  ^^^^^^^ source iterator found here
 ...
 LL |                 let rr = src.next().unwrap();
    |                          ------------------- pointer created here
@@ -10,7 +10,8 @@ LL |                 let rr = src.next().unwrap();
 LL |                 let ss = unsafe { slice::from_raw_parts(rr, hb * s_linesize) };
    |                                   ------------------------------------------ used here to create a slice from the pointer
    |
-   = help: please mark the function as unsafe
+   = help: consider marking the function as unsafe
+   = note: `#[deny(rpl::unvalidated_slice_from_raw_parts)]` on by default
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/cve_2021_25904/cve_2021_25904_src_only.stderr
+++ b/tests/ui/cve_2021_25904/cve_2021_25904_src_only.stderr
@@ -2,7 +2,7 @@ error: it is unsound to trust pointers from passed-in iterators in a public safe
   --> tests/ui/cve_2021_25904/cve_2021_25904_src_only.rs:4:35
    |
 LL | pub fn copy_from_raw_parts<I, IU>(mut src: I, mut src_linesize: IU)
-   |                                   ^^^^^^^
+   |                                   ^^^^^^^ source iterator found here
 ...
 LL |     let rr = src.next().unwrap();
    |                         -------- pointer created here
@@ -10,7 +10,8 @@ LL |     let s_linesize = src_linesize.next().unwrap();
 LL |     let ss = unsafe { slice::from_raw_parts(rr, s_linesize) };
    |                       ------------------------------------- used here to create a slice from the pointer
    |
-   = help: please mark the function as unsafe
+   = help: consider marking the function as unsafe
+   = note: `#[deny(rpl::unvalidated_slice_from_raw_parts)]` on by default
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/cve_2021_25904/cve_2021_25904_src_only_not_inlined.stderr
+++ b/tests/ui/cve_2021_25904/cve_2021_25904_src_only_not_inlined.stderr
@@ -2,7 +2,7 @@ error: it is unsound to trust pointers from passed-in iterators in a public safe
   --> tests/ui/cve_2021_25904/cve_2021_25904_src_only_not_inlined.rs:5:35
    |
 LL | pub fn copy_from_raw_parts<I, IU>(mut src: I, mut src_linesize: IU)
-   |                                   ^^^^^^^
+   |                                   ^^^^^^^ source iterator found here
 ...
 LL |     let rr = src.next().unwrap();
    |              ------------------- pointer created here
@@ -10,7 +10,8 @@ LL |     let s_linesize = src_linesize.next().unwrap();
 LL |     let ss = unsafe { slice::from_raw_parts(rr, s_linesize) };
    |                       ------------------------------------- used here to create a slice from the pointer
    |
-   = help: please mark the function as unsafe
+   = help: consider marking the function as unsafe
+   = note: `#[deny(rpl::unvalidated_slice_from_raw_parts)]` on by default
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/cve_2021_27376/src/adjusted.stderr
+++ b/tests/ui/cve_2021_27376/src/adjusted.stderr
@@ -2,7 +2,7 @@ error: wrong assumption of layout compatibility from `std::net::SocketAddrV4` to
   --> tests/ui/cve_2021_27376/src/adjusted.rs:24:13
    |
 LL |             addr as *const SocketAddrV4 as *const sockaddr,
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ casted to `libc::sockaddr` here
    |
    = help: it's not guaranteed by Rust standard library. See https://github.com/rust-lang/rust/pull/78802
 note: casted from this
@@ -10,12 +10,13 @@ note: casted from this
    |
 LL |             addr as *const SocketAddrV4 as *const sockaddr,
    |             ^^^^
+   = note: `#[deny(rpl::wrong_assumption_of_layout_compatibility)]` on by default
 
 error: wrong assumption of layout compatibility from `std::net::SocketAddrV6` to `libc::sockaddr`
   --> tests/ui/cve_2021_27376/src/adjusted.rs:34:13
    |
 LL |             addr as *const SocketAddrV6 as *const sockaddr,
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ casted to `libc::sockaddr` here
    |
    = help: it's not guaranteed by Rust standard library. See https://github.com/rust-lang/rust/pull/78802
 note: casted from this

--- a/tests/ui/cve_2021_27376/src/adjusted_not_inlined.stderr
+++ b/tests/ui/cve_2021_27376/src/adjusted_not_inlined.stderr
@@ -2,7 +2,7 @@ error: wrong assumption of layout compatibility from `std::net::SocketAddrV4` to
   --> tests/ui/cve_2021_27376/src/adjusted_not_inlined.rs:25:13
    |
 LL |             addr as *const SocketAddrV4 as *const sockaddr,
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ casted to `libc::sockaddr` here
    |
    = help: it's not guaranteed by Rust standard library. See https://github.com/rust-lang/rust/pull/78802
 note: casted from this
@@ -10,12 +10,13 @@ note: casted from this
    |
 LL |             addr as *const SocketAddrV4 as *const sockaddr,
    |             ^^^^
+   = note: `#[deny(rpl::wrong_assumption_of_layout_compatibility)]` on by default
 
 error: wrong assumption of layout compatibility from `std::net::SocketAddrV6` to `libc::sockaddr`
   --> tests/ui/cve_2021_27376/src/adjusted_not_inlined.rs:35:13
    |
 LL |             addr as *const SocketAddrV6 as *const sockaddr,
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ casted to `libc::sockaddr` here
    |
    = help: it's not guaranteed by Rust standard library. See https://github.com/rust-lang/rust/pull/78802
 note: casted from this

--- a/tests/ui/cve_2021_27376/src/lib.stderr
+++ b/tests/ui/cve_2021_27376/src/lib.stderr
@@ -2,7 +2,7 @@ error: wrong assumption of layout compatibility from `std::net::SocketAddrV6` to
   --> tests/ui/cve_2021_27376/src/lib.rs:24:17
    |
 LL |                 addr as *const SocketAddrV6 as *const sockaddr,
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ casted to `libc::sockaddr` here
    |
    = help: it's not guaranteed by Rust standard library. See https://github.com/rust-lang/rust/pull/78802
 note: casted from this
@@ -10,12 +10,13 @@ note: casted from this
    |
 LL |                 addr as *const SocketAddrV6 as *const sockaddr,
    |                 ^^^^
+   = note: `#[deny(rpl::wrong_assumption_of_layout_compatibility)]` on by default
 
 error: wrong assumption of layout compatibility from `std::net::SocketAddrV4` to `libc::sockaddr`
   --> tests/ui/cve_2021_27376/src/lib.rs:19:17
    |
 LL |                 addr as *const SocketAddrV4 as *const sockaddr,
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ casted to `libc::sockaddr` here
    |
    = help: it's not guaranteed by Rust standard library. See https://github.com/rust-lang/rust/pull/78802
 note: casted from this

--- a/tests/ui/cve_2021_27376/src/lib_not_inlined.stderr
+++ b/tests/ui/cve_2021_27376/src/lib_not_inlined.stderr
@@ -2,7 +2,7 @@ error: wrong assumption of layout compatibility from `std::net::SocketAddrV6` to
   --> tests/ui/cve_2021_27376/src/lib_not_inlined.rs:25:17
    |
 LL |                 addr as *const SocketAddrV6 as *const sockaddr,
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ casted to `libc::sockaddr` here
    |
    = help: it's not guaranteed by Rust standard library. See https://github.com/rust-lang/rust/pull/78802
 note: casted from this
@@ -10,12 +10,13 @@ note: casted from this
    |
 LL |                 addr as *const SocketAddrV6 as *const sockaddr,
    |                 ^^^^
+   = note: `#[deny(rpl::wrong_assumption_of_layout_compatibility)]` on by default
 
 error: wrong assumption of layout compatibility from `std::net::SocketAddrV4` to `libc::sockaddr`
   --> tests/ui/cve_2021_27376/src/lib_not_inlined.rs:20:17
    |
 LL |                 addr as *const SocketAddrV4 as *const sockaddr,
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ casted to `libc::sockaddr` here
    |
    = help: it's not guaranteed by Rust standard library. See https://github.com/rust-lang/rust/pull/78802
 note: casted from this

--- a/tests/ui/cve_2021_27376/src/minimal.stderr
+++ b/tests/ui/cve_2021_27376/src/minimal.stderr
@@ -2,7 +2,7 @@ error: wrong assumption of layout compatibility from `std::net::SocketAddrV6` to
   --> tests/ui/cve_2021_27376/src/minimal.rs:6:14
    |
 LL |     let t2 = s as *const libc::sockaddr;
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ casted to `libc::sockaddr` here
    |
    = help: it's not guaranteed by Rust standard library. See https://github.com/rust-lang/rust/pull/78802
 note: casted from this
@@ -10,12 +10,13 @@ note: casted from this
    |
 LL |     let t2 = s as *const libc::sockaddr;
    |              ^
+   = note: `#[deny(rpl::wrong_assumption_of_layout_compatibility)]` on by default
 
 error: wrong assumption of layout compatibility from `std::net::SocketAddrV4` to `libc::sockaddr`
   --> tests/ui/cve_2021_27376/src/minimal.rs:3:14
    |
 LL |     let t1 = s as *const libc::sockaddr;
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ casted to `libc::sockaddr` here
    |
    = help: it's not guaranteed by Rust standard library. See https://github.com/rust-lang/rust/pull/78802
 note: casted from this

--- a/tests/ui/cve_2021_29941_2/cve_2021_29941_2.stderr
+++ b/tests/ui/cve_2021_29941_2/cve_2021_29941_2.stderr
@@ -29,9 +29,10 @@ LL |     let len = bla.len();
    |               --------- `std::iter::ExactSizeIterator::len` used here
 ...
 LL |         vec.set_len(len);
-   |             ^^^^^^^^^^^^
+   |             ^^^^^^^^^^^^ length used here in `Vec::set_len`
    |
-   = help: incorrect implementation of `std::iter::ExactSizeIterator::len` must not cause safety issues
+   = help: incorrect implementation of `std::iter::ExactSizeIterator::len` must not cause safety issues, and consider using `std::iter::TrustedLen` instead if it's stabilized
+   = note: `#[deny(rpl::trust_exact_size_iterator)]` on by default
 
 error: it violates the precondition of `std::slice::from_raw_parts_mut` to create a slice from uninitialized data
   --> tests/ui/cve_2021_29941_2/cve_2021_29941_2.rs:5:36
@@ -40,11 +41,13 @@ LL |     let mut vec = Vec::with_capacity(len);
    |                   ----------------------- `std::vec::Vec` created but not initialized
 LL |     let arr: &mut [u32] = unsafe { std::slice::from_raw_parts_mut(vec.as_mut_ptr(), bla.len()) };
    |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^------------^^---------^
-   |                                                                       |             |
-   |                                                                       |             slice created with this length
-   |                                                                       slice created with this pointer
+   |                                    |                                  |             |
+   |                                    |                                  |             slice created with this length
+   |                                    |                                  slice created with this pointer
+   |                                    slice created here
    |
    = help: See https://doc.rust-lang.org/std/slice/fn.std::slice::from_raw_parts_mut.html
+   = note: `#[deny(rpl::slice_from_raw_parts_uninitialized)]` on by default
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/cve_2021_29941_2/cve_2021_29941_2.stderr
+++ b/tests/ui/cve_2021_29941_2/cve_2021_29941_2.stderr
@@ -20,8 +20,7 @@ LL |         vec.set_len(len);
    |             ^^^^^^^^^^^^ `Vec::set_len` called here
    |
    = help: before calling `set_len` to extend its length, make sure all elements are initialized, using such as `spare_capacity_mut` or `as_mut_ptr`
-   = note: `-D rpl::set-len-uninitialized` implied by `-D warnings`
-   = help: to override `-D warnings` add `#[allow(rpl::set_len_uninitialized)]`
+   = note: `#[deny(rpl::set_len_uninitialized)]` on by default
 
 error: it is unsound to trust return value of `std::iter::ExactSizeIterator::len` and pass it to an unsafe function like `std::vec::Vec::set_len`, which may leak uninitialized memory
   --> tests/ui/cve_2021_29941_2/cve_2021_29941_2.rs:12:13

--- a/tests/ui/cve_2021_29941_2/cve_2021_29941_2.stderr
+++ b/tests/ui/cve_2021_29941_2/cve_2021_29941_2.stderr
@@ -5,9 +5,10 @@ LL |     let mut vec = Vec::with_capacity(len);
    |                   ----------------------- `Vec` created here
 ...
 LL |         vec.set_len(len);
-   |             ^^^^^^^^^^^^
+   |             ^^^^^^^^^^^^ `Vec::set_len` called here
    |
    = note: make sure all elements are initialized before using them
+   = note: `#[deny(rpl::set_len_to_extend)]` on by default
 
 error: it violates the precondition of `Vec::set_len` to extend a `Vec`'s length without initializing its content in advance
   --> tests/ui/cve_2021_29941_2/cve_2021_29941_2.rs:12:13
@@ -16,9 +17,11 @@ LL |     let mut vec = Vec::with_capacity(len);
    |                   ----------------------- `Vec` created here
 ...
 LL |         vec.set_len(len);
-   |             ^^^^^^^^^^^^
+   |             ^^^^^^^^^^^^ `Vec::set_len` called here
    |
    = help: before calling `set_len` to extend its length, make sure all elements are initialized, using such as `spare_capacity_mut` or `as_mut_ptr`
+   = note: `-D rpl::set-len-uninitialized` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(rpl::set_len_uninitialized)]`
 
 error: it is unsound to trust return value of `std::iter::ExactSizeIterator::len` and pass it to an unsafe function like `std::vec::Vec::set_len`, which may leak uninitialized memory
   --> tests/ui/cve_2021_29941_2/cve_2021_29941_2.rs:12:13

--- a/tests/ui/cve_2021_29941_2/cve_2021_29941_2_from_raw_parts.stderr
+++ b/tests/ui/cve_2021_29941_2/cve_2021_29941_2_from_raw_parts.stderr
@@ -20,8 +20,7 @@ LL |         vec.set_len(len);
    |             ^^^^^^^^^^^^ `Vec::set_len` called here
    |
    = help: before calling `set_len` to extend its length, make sure all elements are initialized, using such as `spare_capacity_mut` or `as_mut_ptr`
-   = note: `-D rpl::set-len-uninitialized` implied by `-D warnings`
-   = help: to override `-D warnings` add `#[allow(rpl::set_len_uninitialized)]`
+   = note: `#[deny(rpl::set_len_uninitialized)]` on by default
 
 error: it is unsound to trust return value of `std::iter::ExactSizeIterator::len` and pass it to an unsafe function like `std::vec::Vec::set_len`, which may leak uninitialized memory
   --> tests/ui/cve_2021_29941_2/cve_2021_29941_2_from_raw_parts.rs:12:13

--- a/tests/ui/cve_2021_29941_2/cve_2021_29941_2_from_raw_parts.stderr
+++ b/tests/ui/cve_2021_29941_2/cve_2021_29941_2_from_raw_parts.stderr
@@ -5,9 +5,10 @@ LL |     let mut vec = Vec::with_capacity(len);
    |                   ----------------------- `Vec` created here
 ...
 LL |         vec.set_len(len);
-   |             ^^^^^^^^^^^^
+   |             ^^^^^^^^^^^^ `Vec::set_len` called here
    |
    = note: make sure all elements are initialized before using them
+   = note: `#[deny(rpl::set_len_to_extend)]` on by default
 
 error: it violates the precondition of `Vec::set_len` to extend a `Vec`'s length without initializing its content in advance
   --> tests/ui/cve_2021_29941_2/cve_2021_29941_2_from_raw_parts.rs:12:13
@@ -16,9 +17,11 @@ LL |     let mut vec = Vec::with_capacity(len);
    |                   ----------------------- `Vec` created here
 ...
 LL |         vec.set_len(len);
-   |             ^^^^^^^^^^^^
+   |             ^^^^^^^^^^^^ `Vec::set_len` called here
    |
    = help: before calling `set_len` to extend its length, make sure all elements are initialized, using such as `spare_capacity_mut` or `as_mut_ptr`
+   = note: `-D rpl::set-len-uninitialized` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(rpl::set_len_uninitialized)]`
 
 error: it is unsound to trust return value of `std::iter::ExactSizeIterator::len` and pass it to an unsafe function like `std::vec::Vec::set_len`, which may leak uninitialized memory
   --> tests/ui/cve_2021_29941_2/cve_2021_29941_2_from_raw_parts.rs:12:13

--- a/tests/ui/cve_2021_29941_2/cve_2021_29941_2_from_raw_parts.stderr
+++ b/tests/ui/cve_2021_29941_2/cve_2021_29941_2_from_raw_parts.stderr
@@ -29,9 +29,10 @@ LL |     let len = bla.len();
    |               --------- `std::iter::ExactSizeIterator::len` used here
 ...
 LL |         vec.set_len(len);
-   |             ^^^^^^^^^^^^
+   |             ^^^^^^^^^^^^ length used here in `Vec::set_len`
    |
-   = help: incorrect implementation of `std::iter::ExactSizeIterator::len` must not cause safety issues
+   = help: incorrect implementation of `std::iter::ExactSizeIterator::len` must not cause safety issues, and consider using `std::iter::TrustedLen` instead if it's stabilized
+   = note: `#[deny(rpl::trust_exact_size_iterator)]` on by default
 
 error: it violates the precondition of `std::slice::from_raw_parts_mut` to create a slice from uninitialized data
   --> tests/ui/cve_2021_29941_2/cve_2021_29941_2_from_raw_parts.rs:5:36
@@ -42,10 +43,12 @@ LL |     let mut vec = Vec::with_capacity(len);
    |                   ----------------------- `std::vec::Vec` created but not initialized
 LL |     let arr: &mut [u32] = unsafe { std::slice::from_raw_parts_mut(vec.as_mut_ptr(), len) };
    |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^------------^^^^^^
-   |                                                                       |
-   |                                                                       slice created with this pointer
+   |                                    |                                  |
+   |                                    |                                  slice created with this pointer
+   |                                    slice created here
    |
    = help: See https://doc.rust-lang.org/std/slice/fn.std::slice::from_raw_parts_mut.html
+   = note: `#[deny(rpl::slice_from_raw_parts_uninitialized)]` on by default
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/cve_2021_29941_2/cve_2021_29941_2_not_inlined.stderr
+++ b/tests/ui/cve_2021_29941_2/cve_2021_29941_2_not_inlined.stderr
@@ -17,9 +17,10 @@ LL |     let len = bla.len();
    |               --------- `std::iter::ExactSizeIterator::len` used here
 ...
 LL |         vec.set_len(len);
-   |         ^^^^^^^^^^^^^^^^
+   |         ^^^^^^^^^^^^^^^^ length used here in `Vec::set_len`
    |
-   = help: incorrect implementation of `std::iter::ExactSizeIterator::len` must not cause safety issues
+   = help: incorrect implementation of `std::iter::ExactSizeIterator::len` must not cause safety issues, and consider using `std::iter::TrustedLen` instead if it's stabilized
+   = note: `#[deny(rpl::trust_exact_size_iterator)]` on by default
 
 error: it violates the precondition of `std::slice::from_raw_parts_mut` to create a slice from uninitialized data
   --> tests/ui/cve_2021_29941_2/cve_2021_29941_2_not_inlined.rs:7:36
@@ -28,11 +29,13 @@ LL |     let mut vec = Vec::with_capacity(len);
    |                   ----------------------- `std::vec::Vec` created but not initialized
 LL |     let arr: &mut [u32] = unsafe { std::slice::from_raw_parts_mut(vec.as_mut_ptr(), bla.len()) };
    |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^----------------^^---------^
-   |                                                                   |                 |
-   |                                                                   |                 slice created with this length
-   |                                                                   slice created with this pointer
+   |                                    |                              |                 |
+   |                                    |                              |                 slice created with this length
+   |                                    |                              slice created with this pointer
+   |                                    slice created here
    |
    = help: See https://doc.rust-lang.org/std/slice/fn.std::slice::from_raw_parts_mut.html
+   = note: `#[deny(rpl::slice_from_raw_parts_uninitialized)]` on by default
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/cve_2021_29941_2/cve_2021_29941_2_not_inlined.stderr
+++ b/tests/ui/cve_2021_29941_2/cve_2021_29941_2_not_inlined.stderr
@@ -8,8 +8,7 @@ LL |         vec.set_len(len);
    |         ^^^^^^^^^^^^^^^^ `Vec::set_len` called here
    |
    = help: before calling `set_len` to extend its length, make sure all elements are initialized, using such as `spare_capacity_mut` or `as_mut_ptr`
-   = note: `-D rpl::set-len-uninitialized` implied by `-D warnings`
-   = help: to override `-D warnings` add `#[allow(rpl::set_len_uninitialized)]`
+   = note: `#[deny(rpl::set_len_uninitialized)]` on by default
 
 error: it is unsound to trust return value of `std::iter::ExactSizeIterator::len` and pass it to an unsafe function like `std::vec::Vec::set_len`, which may leak uninitialized memory
   --> tests/ui/cve_2021_29941_2/cve_2021_29941_2_not_inlined.rs:14:9

--- a/tests/ui/cve_2021_29941_2/cve_2021_29941_2_not_inlined.stderr
+++ b/tests/ui/cve_2021_29941_2/cve_2021_29941_2_not_inlined.stderr
@@ -5,9 +5,11 @@ LL |     let mut vec = Vec::with_capacity(len);
    |                   ----------------------- `Vec` created here
 ...
 LL |         vec.set_len(len);
-   |         ^^^^^^^^^^^^^^^^
+   |         ^^^^^^^^^^^^^^^^ `Vec::set_len` called here
    |
    = help: before calling `set_len` to extend its length, make sure all elements are initialized, using such as `spare_capacity_mut` or `as_mut_ptr`
+   = note: `-D rpl::set-len-uninitialized` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(rpl::set_len_uninitialized)]`
 
 error: it is unsound to trust return value of `std::iter::ExactSizeIterator::len` and pass it to an unsafe function like `std::vec::Vec::set_len`, which may leak uninitialized memory
   --> tests/ui/cve_2021_29941_2/cve_2021_29941_2_not_inlined.rs:14:9

--- a/tests/ui/cve_2021_29941_2/cve_2021_29941_2_range_ver.stderr
+++ b/tests/ui/cve_2021_29941_2/cve_2021_29941_2_range_ver.stderr
@@ -20,8 +20,7 @@ LL |         vec.set_len(len);
    |             ^^^^^^^^^^^^ `Vec::set_len` called here
    |
    = help: before calling `set_len` to extend its length, make sure all elements are initialized, using such as `spare_capacity_mut` or `as_mut_ptr`
-   = note: `-D rpl::set-len-uninitialized` implied by `-D warnings`
-   = help: to override `-D warnings` add `#[allow(rpl::set_len_uninitialized)]`
+   = note: `#[deny(rpl::set_len_uninitialized)]` on by default
 
 error: it is unsound to trust return value of `std::iter::ExactSizeIterator::len` and pass it to an unsafe function like `std::vec::Vec::set_len`, which may leak uninitialized memory
   --> tests/ui/cve_2021_29941_2/cve_2021_29941_2_range_ver.rs:20:13

--- a/tests/ui/cve_2021_29941_2/cve_2021_29941_2_range_ver.stderr
+++ b/tests/ui/cve_2021_29941_2/cve_2021_29941_2_range_ver.stderr
@@ -5,9 +5,10 @@ LL |     let mut vec = Vec::with_capacity(len);
    |                   ----------------------- `Vec` created here
 ...
 LL |         vec.set_len(len);
-   |             ^^^^^^^^^^^^
+   |             ^^^^^^^^^^^^ `Vec::set_len` called here
    |
    = note: make sure all elements are initialized before using them
+   = note: `#[deny(rpl::set_len_to_extend)]` on by default
 
 error: it violates the precondition of `Vec::set_len` to extend a `Vec`'s length without initializing its content in advance
   --> tests/ui/cve_2021_29941_2/cve_2021_29941_2_range_ver.rs:20:13
@@ -16,9 +17,11 @@ LL |     let mut vec = Vec::with_capacity(len);
    |                   ----------------------- `Vec` created here
 ...
 LL |         vec.set_len(len);
-   |             ^^^^^^^^^^^^
+   |             ^^^^^^^^^^^^ `Vec::set_len` called here
    |
    = help: before calling `set_len` to extend its length, make sure all elements are initialized, using such as `spare_capacity_mut` or `as_mut_ptr`
+   = note: `-D rpl::set-len-uninitialized` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(rpl::set_len_uninitialized)]`
 
 error: it is unsound to trust return value of `std::iter::ExactSizeIterator::len` and pass it to an unsafe function like `std::vec::Vec::set_len`, which may leak uninitialized memory
   --> tests/ui/cve_2021_29941_2/cve_2021_29941_2_range_ver.rs:20:13

--- a/tests/ui/cve_2021_29941_2/cve_2021_29941_2_range_ver.stderr
+++ b/tests/ui/cve_2021_29941_2/cve_2021_29941_2_range_ver.stderr
@@ -29,9 +29,10 @@ LL |     let len = bla.len();
    |               --------- `std::iter::ExactSizeIterator::len` used here
 ...
 LL |         vec.set_len(len);
-   |             ^^^^^^^^^^^^
+   |             ^^^^^^^^^^^^ length used here in `Vec::set_len`
    |
-   = help: incorrect implementation of `std::iter::ExactSizeIterator::len` must not cause safety issues
+   = help: incorrect implementation of `std::iter::ExactSizeIterator::len` must not cause safety issues, and consider using `std::iter::TrustedLen` instead if it's stabilized
+   = note: `#[deny(rpl::trust_exact_size_iterator)]` on by default
 
 error: it violates the precondition of `std::slice::from_raw_parts_mut` to create a slice from uninitialized data
   --> tests/ui/cve_2021_29941_2/cve_2021_29941_2_range_ver.rs:4:36
@@ -40,11 +41,13 @@ LL |     let mut vec = Vec::with_capacity(len);
    |                   ----------------------- `std::vec::Vec` created but not initialized
 LL |     let arr: &mut [u32] = unsafe { std::slice::from_raw_parts_mut(vec.as_mut_ptr(), bla.len()) };
    |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^------------^^---------^
-   |                                                                       |             |
-   |                                                                       |             slice created with this length
-   |                                                                       slice created with this pointer
+   |                                    |                                  |             |
+   |                                    |                                  |             slice created with this length
+   |                                    |                                  slice created with this pointer
+   |                                    slice created here
    |
    = help: See https://doc.rust-lang.org/std/slice/fn.std::slice::from_raw_parts_mut.html
+   = note: `#[deny(rpl::slice_from_raw_parts_uninitialized)]` on by default
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/cve_2021_29941_2/cve_2021_29941_2_trust_len.stderr
+++ b/tests/ui/cve_2021_29941_2/cve_2021_29941_2_trust_len.stderr
@@ -5,9 +5,10 @@ LL |     let mut vec = Vec::new();
    |                   ---------- `Vec` created here
 ...
 LL |         vec.set_len(len);
-   |             ^^^^^^^^^^^^
+   |             ^^^^^^^^^^^^ `Vec::set_len` called here
    |
    = note: make sure all elements are initialized before using them
+   = note: `#[deny(rpl::set_len_to_extend)]` on by default
 
 error: it is unsound to trust return value of `std::iter::ExactSizeIterator::len` and pass it to an unsafe function like `std::vec::Vec::set_len`, which may leak uninitialized memory
   --> tests/ui/cve_2021_29941_2/cve_2021_29941_2_trust_len.rs:12:13

--- a/tests/ui/cve_2021_29941_2/cve_2021_29941_2_trust_len.stderr
+++ b/tests/ui/cve_2021_29941_2/cve_2021_29941_2_trust_len.stderr
@@ -17,9 +17,10 @@ LL |     let len = bla.len();
    |               --------- `std::iter::ExactSizeIterator::len` used here
 ...
 LL |         vec.set_len(len);
-   |             ^^^^^^^^^^^^
+   |             ^^^^^^^^^^^^ length used here in `Vec::set_len`
    |
-   = help: incorrect implementation of `std::iter::ExactSizeIterator::len` must not cause safety issues
+   = help: incorrect implementation of `std::iter::ExactSizeIterator::len` must not cause safety issues, and consider using `std::iter::TrustedLen` instead if it's stabilized
+   = note: `#[deny(rpl::trust_exact_size_iterator)]` on by default
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/cve_2021_29941_2/cve_2021_29941_2_trust_len_not_inlined.stderr
+++ b/tests/ui/cve_2021_29941_2/cve_2021_29941_2_trust_len_not_inlined.stderr
@@ -5,9 +5,10 @@ LL |     let len = bla.len();
    |               --------- `std::iter::ExactSizeIterator::len` used here
 ...
 LL |         vec.set_len(len);
-   |         ^^^^^^^^^^^^^^^^
+   |         ^^^^^^^^^^^^^^^^ length used here in `Vec::set_len`
    |
-   = help: incorrect implementation of `std::iter::ExactSizeIterator::len` must not cause safety issues
+   = help: incorrect implementation of `std::iter::ExactSizeIterator::len` must not cause safety issues, and consider using `std::iter::TrustedLen` instead if it's stabilized
+   = note: `#[deny(rpl::trust_exact_size_iterator)]` on by default
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/cve_2021_45688/cve_2021_45688.stderr
+++ b/tests/ui/cve_2021_45688/cve_2021_45688.stderr
@@ -20,8 +20,7 @@ LL |         result.set_len(words);
    |                ^^^^^^^^^^^^^^ `Vec::set_len` called here
    |
    = help: before calling `set_len` to extend its length, make sure all elements are initialized, using such as `spare_capacity_mut` or `as_mut_ptr`
-   = note: `-D rpl::set-len-uninitialized` implied by `-D warnings`
-   = help: to override `-D warnings` add `#[allow(rpl::set_len_uninitialized)]`
+   = note: `#[deny(rpl::set_len_uninitialized)]` on by default
 
 error: it violates the precondition of `std::slice::from_raw_parts_mut` to create a slice from uninitialized data
   --> tests/ui/cve_2021_45688/cve_2021_45688.rs:29:21

--- a/tests/ui/cve_2021_45688/cve_2021_45688.stderr
+++ b/tests/ui/cve_2021_45688/cve_2021_45688.stderr
@@ -5,9 +5,10 @@ LL |     let mut result = Vec::<u32>::with_capacity(words);
    |                      -------------------------------- `Vec` created here
 ...
 LL |         result.set_len(words);
-   |                ^^^^^^^^^^^^^^
+   |                ^^^^^^^^^^^^^^ `Vec::set_len` called here
    |
    = note: make sure all elements are initialized before using them
+   = note: `#[deny(rpl::set_len_to_extend)]` on by default
 
 error: it violates the precondition of `Vec::set_len` to extend a `Vec`'s length without initializing its content in advance
   --> tests/ui/cve_2021_45688/cve_2021_45688.rs:23:16
@@ -16,9 +17,11 @@ LL |     let mut result = Vec::<u32>::with_capacity(words);
    |                      -------------------------------- `Vec` created here
 ...
 LL |         result.set_len(words);
-   |                ^^^^^^^^^^^^^^
+   |                ^^^^^^^^^^^^^^ `Vec::set_len` called here
    |
    = help: before calling `set_len` to extend its length, make sure all elements are initialized, using such as `spare_capacity_mut` or `as_mut_ptr`
+   = note: `-D rpl::set-len-uninitialized` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(rpl::set_len_uninitialized)]`
 
 error: it violates the precondition of `std::slice::from_raw_parts_mut` to create a slice from uninitialized data
   --> tests/ui/cve_2021_45688/cve_2021_45688.rs:29:21

--- a/tests/ui/cve_2021_45688/cve_2021_45688.stderr
+++ b/tests/ui/cve_2021_45688/cve_2021_45688.stderr
@@ -31,10 +31,12 @@ LL |     let mut result = Vec::<u32>::with_capacity(words);
 LL |         for word in &mut result {
    |                     ^^^^^^^^^^^
    |                     |
+   |                     slice created here
    |                     slice created with this length
    |                     slice created with this pointer
    |
    = help: See https://doc.rust-lang.org/std/slice/fn.std::slice::from_raw_parts_mut.html
+   = note: `#[deny(rpl::slice_from_raw_parts_uninitialized)]` on by default
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/cve_2022_23639/cve_2022_23639.stderr
+++ b/tests/ui/cve_2022_23639/cve_2022_23639.stderr
@@ -3,10 +3,12 @@ error: it is unsound to cast between `u64` and `AtomicU64`
    |
 LL |         let a = unsafe { &*(self.value.get() as *const AtomicU64) };
    |                            ^----------------^^^^^^^^^^^^^^^^^^^^^
-   |                             |
-   |                             u64 created here
+   |                            ||
+   |                            |u64 created here
+   |                            casted here
    |
    = note: the alignment of `u64` is smaller than `AtomicU64` on many 32-bits platforms
+   = note: `#[deny(rpl::unsound_cast_between_u64_and_atomic_u64)]` on by default
 
 error: aborting due to 1 previous error
 


### PR DESCRIPTION
Use `LintDiagnostics` and `declare_tool_lint` instead of `Diagnostics` or `declare_lint`.