### PR TITLE
Add lint for private functions marked with #[inline]

### DIFF
--- a/crates/rpl_patterns/messages.en.ftl
+++ b/crates/rpl_patterns/messages.en.ftl
@@ -120,3 +120,8 @@ rpl_patterns_slice_from_raw_parts_uninitialized_ = it violates the precondition 
     .len_label   = slice created with this length
     .ptr_label   = slice created with this pointer
     .help        = See https://doc.rust-lang.org/std/slice/fn.{$fn_name}.html
+
+rpl_patterns_private_function_marked_inline =  it usually isn’t necessary to apply #[inline] to private functions
+    .label = `#[inline]` applied here
+    .note = within a crate, the compiler generally makes good inline decisions
+    .help = See https://matklad.github.io/2021/07/09/inline-in-rust.html

--- a/crates/rpl_patterns/src/errors.rs
+++ b/crates/rpl_patterns/src/errors.rs
@@ -294,3 +294,11 @@ pub struct SliceFromRawPartsUninitialized_ {
     pub ptr: Span,
     pub fn_name: &'static str,
 }
+
+#[derive(LintDiagnostic)]
+#[diag(rpl_patterns_private_function_marked_inline)]
+#[help]
+pub struct PrivateFunctionMarkedInline {
+    #[label(rpl_patterns_label)]
+    pub span: Span,
+}

--- a/crates/rpl_patterns/src/lib.rs
+++ b/crates/rpl_patterns/src/lib.rs
@@ -11,6 +11,7 @@ extern crate rustc_infer;
 extern crate rustc_lint_defs;
 extern crate rustc_macros;
 extern crate rustc_middle;
+extern crate rustc_passes;
 extern crate rustc_session;
 extern crate rustc_span;
 extern crate rustc_trait_selection;
@@ -25,6 +26,7 @@ use rustc_session::config::OptLevel;
 
 mod inline;
 mod normal;
+mod others;
 
 pub(crate) mod errors;
 pub(crate) mod lints;
@@ -63,6 +65,7 @@ static ALL_PATTERNS: &[fn(TyCtxt<'_>, PatCtxt<'_>, ItemId)] = &[
     normal::cve_2021_29941_2::check_item,
     normal::cve_2022_23639::check_item,
     inline::cve_2024_27284::check_item,
+    others::private_function_marked_inline::check_item,
 ];
 
 #[instrument(level = "info", skip_all, fields(item = ?item.owner_id.def_id))]

--- a/crates/rpl_patterns/src/lints.rs
+++ b/crates/rpl_patterns/src/lints.rs
@@ -666,3 +666,25 @@ declare_tool_lint! {
     Deny,
     "detects unsound usage of `#[pin_project]`"
 }
+
+declare_tool_lint! {
+    /// The `rpl::private_and_inline` lint detects private functions that are marked with `#[inline]`.
+    ///
+    /// ### Example
+    ///
+    /// ```rust
+    /// #[inline]
+    /// fn foo() {
+    ///     println!("foo");
+    /// }
+    /// ```
+    ///
+    /// {{produces}}
+    ///
+    /// ### Explanation
+    ///
+    /// It is not necessary to apply `#[inline]` to private functions.
+    pub rpl::PRIVATE_AND_INLINE,
+    Deny,
+    "detects private functions that are marked with `#[inline]`"
+}

--- a/crates/rpl_patterns/src/others/mod.rs
+++ b/crates/rpl_patterns/src/others/mod.rs
@@ -1,0 +1,1 @@
+pub(crate) mod private_function_marked_inline;

--- a/crates/rpl_patterns/src/others/private_function_marked_inline.rs
+++ b/crates/rpl_patterns/src/others/private_function_marked_inline.rs
@@ -1,0 +1,75 @@
+use rpl_context::PatCtxt;
+use rustc_hir::def_id::LocalDefId;
+use rustc_hir::intravisit::{self, Visitor};
+use rustc_hir::{self as hir};
+use rustc_middle::hir::nested_filter::All;
+use rustc_middle::ty::TyCtxt;
+use rustc_span::{sym, Span};
+
+#[instrument(level = "info", skip_all)]
+pub fn check_item(tcx: TyCtxt<'_>, _pcx: PatCtxt<'_>, item_id: hir::ItemId) {
+    let item = tcx.hir().item(item_id);
+    let mut check_ctxt = CheckAttrCtxt { tcx };
+    check_ctxt.visit_item(item);
+}
+
+struct CheckAttrCtxt<'tcx> {
+    tcx: TyCtxt<'tcx>,
+}
+
+impl CheckAttrCtxt<'_> {
+    fn check_inline(&self, def_id: LocalDefId) -> bool {
+        let hir_id = self.tcx.local_def_id_to_hir_id(def_id);
+        let attrs = self.tcx.hir().attrs(hir_id);
+        for attr in attrs {
+            if let [sym::inline, ..] = attr.path().as_slice() {
+                let is_inline = true;
+                let is_never = attr.meta_item_list().is_some_and(|meta_item_list| {
+                    meta_item_list
+                        .iter()
+                        .any(|meta_item| meta_item.ident().is_some_and(|ident| ident.name == sym::never))
+                });
+                if is_inline && !is_never {
+                    return true;
+                }
+            }
+        }
+        false
+    }
+}
+
+impl<'tcx> Visitor<'tcx> for CheckAttrCtxt<'tcx> {
+    type NestedFilter = All;
+    fn nested_visit_map(&mut self) -> Self::Map {
+        self.tcx.hir()
+    }
+
+    #[instrument(level = "debug", skip_all, fields(?item.owner_id))]
+    fn visit_item(&mut self, item: &'tcx hir::Item<'tcx>) -> Self::Result {
+        match item.kind {
+            hir::ItemKind::Trait(hir::IsAuto::No, ..) | hir::ItemKind::Impl(_) | hir::ItemKind::Fn { .. } => {},
+            _ => return,
+        }
+        intravisit::walk_item(self, item);
+    }
+
+    #[instrument(level = "info", skip_all, fields(?def_id))]
+    fn visit_fn(
+        &mut self,
+        kind: intravisit::FnKind<'tcx>,
+        decl: &'tcx hir::FnDecl<'tcx>,
+        body_id: hir::BodyId,
+        _span: Span,
+        def_id: LocalDefId,
+    ) -> Self::Result {
+        if !self.tcx.visibility(def_id).is_public() && self.check_inline(def_id) {
+            self.tcx.emit_node_span_lint(
+                crate::lints::PRIVATE_AND_INLINE,
+                self.tcx.local_def_id_to_hir_id(def_id),
+                _span,
+                crate::errors::PrivateFunctionMarkedInline { span: _span },
+            );
+        }
+        intravisit::walk_fn(self, kind, decl, body_id, def_id);
+    }
+}

--- a/tests/ui/cve_2019_16138/src/lib.rs
+++ b/tests/ui/cve_2019_16138/src/lib.rs
@@ -265,6 +265,7 @@ mod hdr {
             // Advances counter to the next pixel
             #[inline]
             fn advance(&mut self) {
+                //~^ERROR: it usually isn’t necessary to apply #[inline] to private functions
                 self.col += 1;
                 if self.col == self.buf.len() {
                     self.col = 0;
@@ -348,6 +349,7 @@ mod hdr {
 
         #[inline(always)]
         fn read_byte<R: BufRead>(r: &mut R) -> io::Result<u8> {
+        //~^ERROR: it usually isn’t necessary to apply #[inline] to private functions
             let mut buf = [0u8];
             r.read_exact(&mut buf[..])?;
             Ok(buf[0])
@@ -356,6 +358,7 @@ mod hdr {
         // Guarantees that first parameter of set_component will be within pos .. pos+width
         #[inline]
         fn decode_component<R: BufRead, S: FnMut(usize, u8)>(
+        //~^ERROR: it usually isn’t necessary to apply #[inline] to private functions
             r: &mut R,
             width: usize,
             mut set_component: S,
@@ -419,6 +422,8 @@ mod hdr {
             // returns run length if pixel is a run length marker
             #[inline]
             fn rl_marker(pix: RGBE8Pixel) -> Option<usize> {
+            //~^ERROR: it usually isn’t necessary to apply #[inline] to private functions
+            //~|ERROR: it usually isn’t necessary to apply #[inline] to private functions
                 if pix.c == [1, 1, 1] {
                     Some(pix.e as usize)
                 } else {

--- a/tests/ui/cve_2019_16138/src/lib.stderr
+++ b/tests/ui/cve_2019_16138/src/lib.stderr
@@ -64,5 +64,73 @@ LL | ...                   (read_scanline(&mut self.r, &mut buf[..]))?;
    |
    = help: See https://doc.rust-lang.org/std/slice/fn.std::slice::from_raw_parts_mut.html
 
-error: aborting due to 5 previous errors
+error: it usually isn’t necessary to apply #[inline] to private functions
+  --> tests/ui/cve_2019_16138/src/lib.rs:267:13
+   |
+LL | /             fn advance(&mut self) {
+LL | |
+LL | |                 self.col += 1;
+LL | |                 if self.col == self.buf.len() {
+...  |
+LL | |             }
+   | |_____________^ `#[inline]` applied here
+   |
+   = help: See https://matklad.github.io/2021/07/09/inline-in-rust.html
+   = note: `#[deny(rpl::private_and_inline)]` on by default
+
+error: it usually isn’t necessary to apply #[inline] to private functions
+  --> tests/ui/cve_2019_16138/src/lib.rs:351:9
+   |
+LL | /         fn read_byte<R: BufRead>(r: &mut R) -> io::Result<u8> {
+LL | |
+LL | |             let mut buf = [0u8];
+LL | |             r.read_exact(&mut buf[..])?;
+LL | |             Ok(buf[0])
+LL | |         }
+   | |_________^ `#[inline]` applied here
+   |
+   = help: See https://matklad.github.io/2021/07/09/inline-in-rust.html
+
+error: it usually isn’t necessary to apply #[inline] to private functions
+  --> tests/ui/cve_2019_16138/src/lib.rs:360:9
+   |
+LL | /         fn decode_component<R: BufRead, S: FnMut(usize, u8)>(
+LL | |
+LL | |             r: &mut R,
+LL | |             width: usize,
+...  |
+LL | |             Ok(())
+LL | |         }
+   | |_________^ `#[inline]` applied here
+   |
+   = help: See https://matklad.github.io/2021/07/09/inline-in-rust.html
+
+error: it usually isn’t necessary to apply #[inline] to private functions
+  --> tests/ui/cve_2019_16138/src/lib.rs:424:13
+   |
+LL | /             fn rl_marker(pix: RGBE8Pixel) -> Option<usize> {
+LL | |
+LL | |
+LL | |                 if pix.c == [1, 1, 1] {
+...  |
+LL | |             }
+   | |_____________^ `#[inline]` applied here
+   |
+   = help: See https://matklad.github.io/2021/07/09/inline-in-rust.html
+
+error: it usually isn’t necessary to apply #[inline] to private functions
+  --> tests/ui/cve_2019_16138/src/lib.rs:424:13
+   |
+LL | /             fn rl_marker(pix: RGBE8Pixel) -> Option<usize> {
+LL | |
+LL | |
+LL | |                 if pix.c == [1, 1, 1] {
+...  |
+LL | |             }
+   | |_____________^ `#[inline]` applied here
+   |
+   = help: See https://matklad.github.io/2021/07/09/inline-in-rust.html
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: aborting due to 10 previous errors
 

--- a/tests/ui/cve_2019_16138/src/lib_not_inlined.rs
+++ b/tests/ui/cve_2019_16138/src/lib_not_inlined.rs
@@ -261,6 +261,7 @@ mod hdr {
             // Advances counter to the next pixel
             #[inline]
             fn advance(&mut self) {
+            //~^ERROR: it usually isn’t necessary to apply #[inline] to private functions
                 self.col += 1;
                 if self.col == self.buf.len() {
                     self.col = 0;
@@ -344,6 +345,7 @@ mod hdr {
 
         #[inline(always)]
         fn read_byte<R: BufRead>(r: &mut R) -> io::Result<u8> {
+        //~^ERROR: it usually isn’t necessary to apply #[inline] to private functions
             let mut buf = [0u8];
             r.read_exact(&mut buf[..])?;
             Ok(buf[0])
@@ -352,6 +354,7 @@ mod hdr {
         // Guarantees that first parameter of set_component will be within pos .. pos+width
         #[inline]
         fn decode_component<R: BufRead, S: FnMut(usize, u8)>(
+        //~^ERROR: it usually isn’t necessary to apply #[inline] to private functions
             r: &mut R,
             width: usize,
             mut set_component: S,
@@ -415,6 +418,8 @@ mod hdr {
             // returns run length if pixel is a run length marker
             #[inline]
             fn rl_marker(pix: RGBE8Pixel) -> Option<usize> {
+            //~^ERROR: it usually isn’t necessary to apply #[inline] to private functions
+            //~|ERROR: it usually isn’t necessary to apply #[inline] to private functions
                 if pix.c == [1, 1, 1] {
                     Some(pix.e as usize)
                 } else {

--- a/tests/ui/cve_2019_16138/src/lib_not_inlined.stderr
+++ b/tests/ui/cve_2019_16138/src/lib_not_inlined.stderr
@@ -21,5 +21,73 @@ LL | ...                       buf.set_len(uszwidth);
    |
    = help: before calling `set_len` to extend its length, make sure all elements are initialized, using such as `spare_capacity_mut` or `as_mut_ptr`
 
-error: aborting due to 2 previous errors
+error: it usually isn’t necessary to apply #[inline] to private functions
+  --> tests/ui/cve_2019_16138/src/lib_not_inlined.rs:263:13
+   |
+LL | /             fn advance(&mut self) {
+LL | |
+LL | |                 self.col += 1;
+LL | |                 if self.col == self.buf.len() {
+...  |
+LL | |             }
+   | |_____________^ `#[inline]` applied here
+   |
+   = help: See https://matklad.github.io/2021/07/09/inline-in-rust.html
+   = note: `#[deny(rpl::private_and_inline)]` on by default
+
+error: it usually isn’t necessary to apply #[inline] to private functions
+  --> tests/ui/cve_2019_16138/src/lib_not_inlined.rs:347:9
+   |
+LL | /         fn read_byte<R: BufRead>(r: &mut R) -> io::Result<u8> {
+LL | |
+LL | |             let mut buf = [0u8];
+LL | |             r.read_exact(&mut buf[..])?;
+LL | |             Ok(buf[0])
+LL | |         }
+   | |_________^ `#[inline]` applied here
+   |
+   = help: See https://matklad.github.io/2021/07/09/inline-in-rust.html
+
+error: it usually isn’t necessary to apply #[inline] to private functions
+  --> tests/ui/cve_2019_16138/src/lib_not_inlined.rs:356:9
+   |
+LL | /         fn decode_component<R: BufRead, S: FnMut(usize, u8)>(
+LL | |
+LL | |             r: &mut R,
+LL | |             width: usize,
+...  |
+LL | |             Ok(())
+LL | |         }
+   | |_________^ `#[inline]` applied here
+   |
+   = help: See https://matklad.github.io/2021/07/09/inline-in-rust.html
+
+error: it usually isn’t necessary to apply #[inline] to private functions
+  --> tests/ui/cve_2019_16138/src/lib_not_inlined.rs:420:13
+   |
+LL | /             fn rl_marker(pix: RGBE8Pixel) -> Option<usize> {
+LL | |
+LL | |
+LL | |                 if pix.c == [1, 1, 1] {
+...  |
+LL | |             }
+   | |_____________^ `#[inline]` applied here
+   |
+   = help: See https://matklad.github.io/2021/07/09/inline-in-rust.html
+
+error: it usually isn’t necessary to apply #[inline] to private functions
+  --> tests/ui/cve_2019_16138/src/lib_not_inlined.rs:420:13
+   |
+LL | /             fn rl_marker(pix: RGBE8Pixel) -> Option<usize> {
+LL | |
+LL | |
+LL | |                 if pix.c == [1, 1, 1] {
+...  |
+LL | |             }
+   | |_____________^ `#[inline]` applied here
+   |
+   = help: See https://matklad.github.io/2021/07/09/inline-in-rust.html
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: aborting due to 7 previous errors
 

--- a/tests/ui/private_function_marked_inline/private_function_marked_inline.rs
+++ b/tests/ui/private_function_marked_inline/private_function_marked_inline.rs
@@ -1,0 +1,45 @@
+#[inline]
+fn foo11() {}
+//~^ERROR: it usually isn’t necessary to apply #[inline] to private functions
+
+#[inline]
+pub(crate) fn foo12() {}
+//~^ERROR: it usually isn’t necessary to apply #[inline] to private functions
+#[inline]
+pub fn foo13() {}
+
+#[inline(always)]
+fn foo21() {}
+//~^ERROR: it usually isn’t necessary to apply #[inline] to private functions
+
+#[inline(always)]
+pub(crate) fn foo22() {}
+//~^ERROR: it usually isn’t necessary to apply #[inline] to private functions
+
+#[inline(always)]
+pub fn foo23() {}
+
+#[inline(never)]
+fn foo31() {}
+
+#[inline(never)]
+pub(crate) fn foo32() {}
+
+#[inline(never)]
+pub fn foo33() {}
+
+trait Trait {
+    #[inline]
+    fn foo_in_trait() {}
+    //~^ERROR: it usually isn’t necessary to apply #[inline] to private functions
+}
+
+struct Struct;
+
+impl Struct {
+    #[inline]
+    fn foo_in_impl() {}
+    //~^ERROR: it usually isn’t necessary to apply #[inline] to private functions
+}
+
+fn main() {}

--- a/tests/ui/private_function_marked_inline/private_function_marked_inline.stderr
+++ b/tests/ui/private_function_marked_inline/private_function_marked_inline.stderr
@@ -1,0 +1,51 @@
+error: it usually isn’t necessary to apply #[inline] to private functions
+  --> tests/ui/private_function_marked_inline/private_function_marked_inline.rs:2:1
+   |
+LL | fn foo11() {}
+   | ^^^^^^^^^^^^^ `#[inline]` applied here
+   |
+   = help: See https://matklad.github.io/2021/07/09/inline-in-rust.html
+   = note: `#[deny(rpl::private_and_inline)]` on by default
+
+error: it usually isn’t necessary to apply #[inline] to private functions
+  --> tests/ui/private_function_marked_inline/private_function_marked_inline.rs:6:1
+   |
+LL | pub(crate) fn foo12() {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^ `#[inline]` applied here
+   |
+   = help: See https://matklad.github.io/2021/07/09/inline-in-rust.html
+
+error: it usually isn’t necessary to apply #[inline] to private functions
+  --> tests/ui/private_function_marked_inline/private_function_marked_inline.rs:12:1
+   |
+LL | fn foo21() {}
+   | ^^^^^^^^^^^^^ `#[inline]` applied here
+   |
+   = help: See https://matklad.github.io/2021/07/09/inline-in-rust.html
+
+error: it usually isn’t necessary to apply #[inline] to private functions
+  --> tests/ui/private_function_marked_inline/private_function_marked_inline.rs:16:1
+   |
+LL | pub(crate) fn foo22() {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^ `#[inline]` applied here
+   |
+   = help: See https://matklad.github.io/2021/07/09/inline-in-rust.html
+
+error: it usually isn’t necessary to apply #[inline] to private functions
+  --> tests/ui/private_function_marked_inline/private_function_marked_inline.rs:33:5
+   |
+LL |     fn foo_in_trait() {}
+   |     ^^^^^^^^^^^^^^^^^^^^ `#[inline]` applied here
+   |
+   = help: See https://matklad.github.io/2021/07/09/inline-in-rust.html
+
+error: it usually isn’t necessary to apply #[inline] to private functions
+  --> tests/ui/private_function_marked_inline/private_function_marked_inline.rs:41:5
+   |
+LL |     fn foo_in_impl() {}
+   |     ^^^^^^^^^^^^^^^^^^^ `#[inline]` applied here
+   |
+   = help: See https://matklad.github.io/2021/07/09/inline-in-rust.html
+
+error: aborting due to 6 previous errors
+


### PR DESCRIPTION
This PR adds a new lint to detect private functions that are marked with the `#[inline]` attribute.
cc @jellllly420.