### PR TITLE
A new `IntTy` for integer literals without suffix

### DIFF
--- a/crates/rpl_context/src/pat/pretty.rs
+++ b/crates/rpl_context/src/pat/pretty.rs
@@ -141,6 +141,7 @@ impl fmt::Display for RegionKind {
 impl fmt::Debug for IntValue {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self.ty {
+            IntTy::AnyInt => write!(f, "{}", self.value),
             IntTy::Bool => write!(f, "{}", self.value != 0),
             IntTy::Int(ty) => write!(f, "{}_{}", self.value, ty.name_str()),
             IntTy::NegInt(ty) => write!(f, "-{}_{}", self.value, ty.name_str()),

--- a/crates/rpl_context/src/pat/ty.rs
+++ b/crates/rpl_context/src/pat/ty.rs
@@ -558,6 +558,7 @@ impl<'pcx> PathWithArgs<'pcx> {
 
 #[derive(PartialEq, Eq, Hash, Clone, Copy)]
 pub enum IntTy {
+    AnyInt,
     NegInt(ty::IntTy),
     Int(ty::IntTy),
     Uint(ty::UintTy),
@@ -624,7 +625,7 @@ impl IntValue {
         let ty = if let Some(ty) = ty {
             IntTy::from(ty)
         } else {
-            IntTy::Uint(ty::UintTy::Usize)
+            IntTy::AnyInt
         };
         Self { value, ty }
     }
@@ -645,7 +646,7 @@ impl IntValue {
 
 impl IntValue {
     pub fn normalize(self, pointer_bytes: u64) -> Pu128 {
-        use IntTy::{Bool, Int, NegInt, Uint};
+        use IntTy::{AnyInt, Bool, Int, NegInt, Uint};
         use ty::IntTy::{I8, I16, I32, I64, I128, Isize};
 
         let IntValue { ty, value } = self;
@@ -661,7 +662,7 @@ impl IntValue {
                 8 => u128::from(u64::MAX),
                 _ => panic!("unsupported pointer size: {pointer_bytes}"),
             },
-            Int(_) | Uint(_) | Bool => return value,
+            AnyInt | Int(_) | Uint(_) | Bool => return value,
         };
         Pu128((value.get() ^ mask).wrapping_add(1) & mask)
     }

--- a/crates/rpl_match/src/statement.rs
+++ b/crates/rpl_match/src/statement.rs
@@ -467,6 +467,7 @@ pub(crate) trait MatchStatement<'pcx, 'tcx> {
             (&pat::ConstOperand::ConstVar(const_var), konst) => self.ty().match_mir_const_var(const_var, konst),
             (&pat::ConstOperand::ScalarInt(value_pat), mir::Const::Val(mir::ConstValue::Scalar(value), ty)) => {
                 (match (value_pat.ty, *ty.kind()) {
+                    (pat::IntTy::AnyInt, ty::Int(_) | ty::Uint(_)) => true,
                     (pat::IntTy::NegInt(ty_pat), ty::Int(ty)) => ty_pat == ty,
                     (pat::IntTy::Int(ty_pat), ty::Int(ty)) => ty_pat == ty,
                     (pat::IntTy::Uint(ty_pat), ty::Uint(ty)) => ty_pat == ty,


### PR DESCRIPTION
An integer literal without suffix now can be matched with any constants with the same mathematical value.