### PR TITLE
Add dev support for Zed

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,13 @@
+{
+    "name": "rpl-dev",
+    "image": "mcr.microsoft.com/devcontainers/rust:latest",
+    "remoteUser": "vscode",
+    "workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}",
+    "containerEnv": {
+        "SHELL": "/bin/zsh"
+    },
+    "mounts": [
+        "source=cargo-registry,target=/usr/local/cargo/registry,type=volume",
+        "source=cargo-git,target=/usr/local/cargo/git,type=volume"
+    ],
+}

--- a/.zed/settings.json
+++ b/.zed/settings.json
@@ -1,0 +1,20 @@
+{
+    "lsp": {
+        "rust-analyzer": {
+            "initialization_options": {
+                "rustc": {
+                    "source": "discover",
+                },
+                "linkedProjects": [
+                    "./Cargo.toml",
+                    "./tests/ui/cross-stmt-and-func-comparison-with-clippy/Cargo.toml",
+                ],
+                "diagnostics": {
+                    "disabled": [
+                        "macro-error"
+                    ],
+                }
+            }
+        }
+    }
+}

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,3 +1,3 @@
 [toolchain]
 channel = "nightly-2025-02-14"
-components = ["cargo", "llvm-tools", "rust-src", "rust-std", "rustc", "rustc-dev", "rustfmt", "clippy"]
+components = ["cargo", "llvm-tools", "rust-src", "rust-std", "rustc", "rustc-dev", "rustfmt", "clippy", "rust-analyzer"]


### PR DESCRIPTION
I've been trying Zed these days so this PR is to see if we need dev support for Zed. Feel free to close it if you think it's unnecessary.

Basically it adds
- an editor-agnostic devcontainer configuration file (which I think is important for Zed) and,
- a Zed configuration file for rust-analyzer to work correctly in our project.