### PR TITLE
rpldoc: documentation feature for RPL pattern files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,7 @@
 *.dot text eol=lf
 *.fixed text eol=lf
+*.md text eol=lf
+*.rpl text eol=lf
 *.rs text eol=lf
 *.sh text eol=lf
 *.stderr text eol=lf

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -125,3 +125,15 @@ For example:
 ```
 RPL_PATS=~/home/code/projects/RPL/docs/patterns/CVE-2019-16138-MIR.rpl RUSTFLAGS=-Zinline-mir=false cargo rpl
 ```
+
+## Documenting Patterns
+
+When writing or substantially revising an `.rpl` file under
+`docs/patterns-pest/`, consider adding a `//!` block at the top
+describing what the pattern detects, and `///` blocks on each
+pattern/util/diag item explaining its role. See
+[`docs/development/rpldoc-authoring.md`](docs/development/rpldoc-authoring.md)
+for conventions and a worked example.
+
+Documentation is encouraged but not enforced; existing pattern files
+without docs continue to work unchanged.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -572,6 +572,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
 name = "filepath"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -739,6 +745,18 @@ dependencies = [
  "cfg-if",
  "libc",
  "wasi",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
 ]
 
 [[package]]
@@ -1392,6 +1410,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
 name = "radium"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1432,7 +1456,7 @@ version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
  "libredox",
  "thiserror",
 ]
@@ -1474,7 +1498,7 @@ checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom",
+ "getrandom 0.2.15",
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
@@ -1505,6 +1529,7 @@ dependencies = [
  "radium",
  "regex",
  "rpl_config",
+ "rpl_doc",
  "rpl_interface",
  "rpl_meta",
  "rustc_tools_util",
@@ -1558,6 +1583,18 @@ dependencies = [
  "rpl_meta",
  "rpl_parser",
  "sync-arena",
+]
+
+[[package]]
+name = "rpl_doc"
+version = "0.1.0"
+dependencies = [
+ "pest",
+ "pretty_assertions",
+ "rpl_parser",
+ "tempfile",
+ "thiserror",
+ "walkdir",
 ]
 
 [[package]]
@@ -2028,6 +2065,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d31c77bdf42a745371d260a26ca7163f1e0924b64afa0b688e61b5a9fa02f16"
+dependencies = [
+ "fastrand",
+ "getrandom 0.3.4",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "term"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2356,6 +2406,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
+name = "wasip2"
+version = "1.0.1+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
 name = "wasm-bindgen"
 version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2588,6 +2647,12 @@ checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
 
 [[package]]
 name = "writeable"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,6 +96,7 @@ path = "src/driver.rs"
 rpl_interface.workspace = true
 rpl_meta.workspace = true
 rpl_config.workspace = true
+rpl_doc.workspace = true
 rustc_tools_util.workspace = true
 color-print = "0.3.4"
 anstream = "0.6.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ rpl_meta = { path = "./crates/rpl_meta" }
 rpl_patterns = { path = "./crates/rpl_patterns" }
 rpl_config = { path = "./crates/rpl_config" }
 rpl_constraints = { path = "./crates/rpl_constraints" }
+rpl_doc = { path = "./crates/rpl_doc" }
 rpl_resolve = { path = "./crates/rpl_resolve" }
 rustc_tools_util = "0.3.0"
 serde = { version = "1.0", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -52,6 +52,16 @@ The toolchain of RPL, which is a custom configuration of Rust compiler, enables 
 
    TIP: You can view all available lints with `cargo rpl -- -W help`.
 
+## Documenting Patterns
+
+You can generate Markdown documentation for any `.rpl` file with:
+
+```sh
+cargo rpl doc path/to/pattern.rpl
+```
+
+See [`docs/development/rpldoc-authoring.md`](./docs/development/rpldoc-authoring.md) for the authoring conventions (`//!` for file-level docs, `///` for items, and the sibling examples folder).
+
 ## RPL Book
 
 See [this website](https://rpl-toolchain.github.io/rpl-book/) for the RPL book (Work in progress).

--- a/crates/rpl_context/src/pat/error.rs
+++ b/crates/rpl_context/src/pat/error.rs
@@ -434,7 +434,7 @@ impl<'i> DynamicErrorBuilder<'i> {
         table: &DiagSymbolTable,
     ) -> Result<Self, ParseError<'i>> {
         let path = item.path;
-        let (_, _, _, diags, _, _) = item.get_matched();
+        let (_, _, _, _, diags, _, _) = item.get_matched();
         let mut primary = None;
         let mut labels = Vec::new();
         let mut notes = Vec::new();

--- a/crates/rpl_context/src/pat/mod.rs
+++ b/crates/rpl_context/src/pat/mod.rs
@@ -402,7 +402,7 @@ impl<'pcx> Pattern<'pcx> {
         block_type: PattOrUtil,
     ) {
         let p = pat_item.path;
-        let (attr, name, meta_decls, _, item_or_patt_op) = pat_item.get_matched();
+        let (_, attr, name, meta_decls, _, item_or_patt_op) = pat_item.get_matched();
         let name = name.span.as_str();
         let symbol_table = symbol_tables.get(&name).unwrap();
         let meta = Arc::new(NonLocalMetaVars::from_meta_decls(
@@ -559,7 +559,7 @@ impl<'pcx> Pattern<'pcx> {
     ) {
         let mut items = FxHashMap::default();
         for item in diag.get_matched().2.iter_matched() {
-            let (ident, _, _, _, _, _) = item.get_matched();
+            let (_, ident, _, _, _, _, _) = item.get_matched();
             let name = Symbol::intern(ident.span.as_str());
             let prev = items.insert(name, item);
             debug_assert!(prev.is_none(), "Duplicate diagnostic for {:?}", name); //FIXME: raise an error

--- a/crates/rpl_doc/Cargo.toml
+++ b/crates/rpl_doc/Cargo.toml
@@ -8,6 +8,8 @@ license.workspace = true
 keywords.workspace = true
 
 [dependencies]
+pest.workspace = true
+rpl_parser.workspace = true
 thiserror.workspace = true
 walkdir.workspace = true
 
@@ -16,3 +18,7 @@ pretty_assertions.workspace = true
 
 [lib]
 doctest = false
+
+[package.metadata.rust-analyzer]
+# This crate transitively uses #[feature(rustc_private)] via rpl_parser
+rustc_private = true

--- a/crates/rpl_doc/Cargo.toml
+++ b/crates/rpl_doc/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "rpl_doc"
+version.workspace = true
+edition.workspace = true
+description.workspace = true
+repository.workspace = true
+license.workspace = true
+keywords.workspace = true
+
+[dependencies]
+thiserror.workspace = true
+walkdir.workspace = true
+
+[dev-dependencies]
+pretty_assertions.workspace = true
+
+[lib]
+doctest = false

--- a/crates/rpl_doc/Cargo.toml
+++ b/crates/rpl_doc/Cargo.toml
@@ -15,6 +15,7 @@ walkdir.workspace = true
 
 [dev-dependencies]
 pretty_assertions.workspace = true
+tempfile = "3"
 
 [lib]
 doctest = false

--- a/crates/rpl_doc/src/error.rs
+++ b/crates/rpl_doc/src/error.rs
@@ -1,0 +1,32 @@
+//! Error types for rpldoc.
+
+use std::io;
+use std::path::PathBuf;
+
+#[derive(thiserror::Error, Debug)]
+pub enum RpldocError {
+    #[error("failed to read {path}: {source}", path = path.display())]
+    Io {
+        path: PathBuf,
+        #[source]
+        source: io::Error,
+    },
+
+    /// Parser produced an error. We carry the formatted message rather than the
+    /// raw `rpl_parser::ParseError<'_>` so that this enum is `'static`.
+    #[error("parse error in {path}:\n{message}", path = path.display())]
+    Parse { path: PathBuf, message: String },
+
+    #[error("{path}: file has no `pattern <Name>` header", path = path.display())]
+    MissingPatternHeader { path: PathBuf },
+
+    #[error("{path}: file is not valid UTF-8", path = path.display())]
+    NotUtf8 { path: PathBuf },
+
+    #[error("failed to write {path}: {source}", path = path.display())]
+    OutputWrite {
+        path: PathBuf,
+        #[source]
+        source: io::Error,
+    },
+}

--- a/crates/rpl_doc/src/examples.rs
+++ b/crates/rpl_doc/src/examples.rs
@@ -1,0 +1,194 @@
+//! Sibling examples folder discovery and rendering.
+//!
+//! For `<dir>/<stem>.rpl`, looks at `<dir>/<stem>/` for `.rs` files.
+
+use crate::error::RpldocError;
+use crate::model::DocExample;
+use std::path::Path;
+
+/// Load `.rs` example files from the sibling folder of `rpl_path`.
+///
+/// Returns an empty `Vec` if the folder doesn't exist. Per-file read errors
+/// are reported to `warn` (caller's responsibility to surface), and the
+/// offending file is skipped.
+pub(crate) fn load_examples(
+    rpl_path: &Path,
+    mut warn: impl FnMut(RpldocError),
+) -> Vec<DocExample> {
+    let stem = match rpl_path.file_stem().and_then(|s| s.to_str()) {
+        Some(s) => s,
+        None => return Vec::new(),
+    };
+    let dir = match rpl_path.parent() {
+        Some(p) => p.join(stem),
+        None => return Vec::new(),
+    };
+    if !dir.is_dir() {
+        return Vec::new();
+    }
+
+    let mut entries: Vec<_> = match std::fs::read_dir(&dir) {
+        Ok(rd) => rd.filter_map(Result::ok).collect(),
+        Err(e) => {
+            warn(RpldocError::Io { path: dir.clone(), source: e });
+            return Vec::new();
+        }
+    };
+    entries.sort_by_key(|e| e.file_name());
+
+    let mut out = Vec::new();
+    for entry in entries {
+        let path = entry.path();
+        if path.extension().and_then(|s| s.to_str()) != Some("rs") {
+            continue;
+        }
+        if !path.is_file() {
+            continue;
+        }
+        let filename = match path.file_name().and_then(|s| s.to_str()) {
+            Some(s) => s.to_string(),
+            None => continue,
+        };
+        let source = match std::fs::read_to_string(&path) {
+            Ok(s) => s,
+            Err(e) => {
+                warn(RpldocError::Io { path: path.clone(), source: e });
+                continue;
+            }
+        };
+        out.push(promote_leading_inner_doc(filename, source));
+    }
+    out
+}
+
+/// Split off any leading `//!` block (the contiguous run of `//!` lines at
+/// the very top of the file, before any other non-blank token).
+fn promote_leading_inner_doc(filename: String, source: String) -> DocExample {
+    let mut leading_doc = Vec::new();
+    let mut consumed_bytes = 0usize;
+    for line in source.split_inclusive('\n') {
+        let trimmed = line.trim_end_matches('\n').trim_end_matches('\r');
+        if trimmed.trim_start().starts_with("//!") {
+            // Capture, stripping prefix and one optional space.
+            let after = trimmed
+                .trim_start()
+                .strip_prefix("//!")
+                .unwrap_or("");
+            let stripped = after.strip_prefix(' ').unwrap_or(after);
+            leading_doc.push(stripped.to_string());
+            consumed_bytes += line.len();
+        } else if trimmed.is_empty() && !leading_doc.is_empty() {
+            // A blank line after a //! run terminates the leading block.
+            consumed_bytes += line.len();
+            break;
+        } else {
+            break;
+        }
+    }
+
+    let rest = if consumed_bytes == 0 {
+        source
+    } else {
+        source[consumed_bytes..].to_string()
+    };
+
+    let leading_runs = if leading_doc.is_empty() {
+        Vec::new()
+    } else {
+        vec![leading_doc.join("\n")]
+    };
+
+    DocExample {
+        filename,
+        leading_doc: leading_runs,
+        source: rest,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    fn make_temp_with_layout(stem: &str, files: &[(&str, &str)]) -> tempfile::TempDir {
+        let td = tempfile::TempDir::new().unwrap();
+        let rpl = td.path().join(format!("{stem}.rpl"));
+        fs::write(&rpl, "pattern X\n").unwrap();
+        let ex_dir = td.path().join(stem);
+        fs::create_dir(&ex_dir).unwrap();
+        for (name, content) in files {
+            fs::write(ex_dir.join(name), content).unwrap();
+        }
+        td
+    }
+
+    #[test]
+    fn empty_when_no_folder() {
+        let td = tempfile::TempDir::new().unwrap();
+        let rpl = td.path().join("Foo.rpl");
+        fs::write(&rpl, "pattern X").unwrap();
+        let mut warnings = Vec::new();
+        let examples = load_examples(&rpl, |w| warnings.push(w));
+        assert!(examples.is_empty());
+        assert!(warnings.is_empty());
+    }
+
+    #[test]
+    fn loads_rs_files_in_lex_order() {
+        let td = make_temp_with_layout(
+            "Foo",
+            &[
+                ("z.rs", "fn z() {}\n"),
+                ("a.rs", "fn a() {}\n"),
+                ("m.rs", "fn m() {}\n"),
+            ],
+        );
+        let rpl = td.path().join("Foo.rpl");
+        let examples = load_examples(&rpl, |_| {});
+        assert_eq!(
+            examples.iter().map(|e| &e.filename).collect::<Vec<_>>(),
+            vec!["a.rs", "m.rs", "z.rs"],
+        );
+    }
+
+    #[test]
+    fn ignores_non_rs_files() {
+        let td = make_temp_with_layout(
+            "Foo",
+            &[("a.rs", "fn a() {}"), ("README.md", "# readme"), ("data.txt", "x")],
+        );
+        let rpl = td.path().join("Foo.rpl");
+        let examples = load_examples(&rpl, |_| {});
+        assert_eq!(examples.len(), 1);
+        assert_eq!(examples[0].filename, "a.rs");
+    }
+
+    #[test]
+    fn promotes_leading_inner_doc_block() {
+        let td = make_temp_with_layout(
+            "Foo",
+            &[(
+                "a.rs",
+                "//! Demonstrates the bug.\n//! Second line.\n\nfn a() {}\n",
+            )],
+        );
+        let rpl = td.path().join("Foo.rpl");
+        let examples = load_examples(&rpl, |_| {});
+        assert_eq!(examples.len(), 1);
+        assert_eq!(
+            examples[0].leading_doc,
+            vec!["Demonstrates the bug.\nSecond line."]
+        );
+        assert_eq!(examples[0].source, "fn a() {}\n");
+    }
+
+    #[test]
+    fn no_promotion_when_no_leading_inner_doc() {
+        let td = make_temp_with_layout("Foo", &[("a.rs", "fn a() {}\n")]);
+        let rpl = td.path().join("Foo.rpl");
+        let examples = load_examples(&rpl, |_| {});
+        assert_eq!(examples.len(), 1);
+        assert!(examples[0].leading_doc.is_empty());
+        assert_eq!(examples[0].source, "fn a() {}\n");
+    }
+}

--- a/crates/rpl_doc/src/examples.rs
+++ b/crates/rpl_doc/src/examples.rs
@@ -2,19 +2,17 @@
 //!
 //! For `<dir>/<stem>.rpl`, looks at `<dir>/<stem>/` for `.rs` files.
 
+use std::path::Path;
+
 use crate::error::RpldocError;
 use crate::model::DocExample;
-use std::path::Path;
 
 /// Load `.rs` example files from the sibling folder of `rpl_path`.
 ///
 /// Returns an empty `Vec` if the folder doesn't exist. Per-file read errors
 /// are reported to `warn` (caller's responsibility to surface), and the
 /// offending file is skipped.
-pub(crate) fn load_examples(
-    rpl_path: &Path,
-    mut warn: impl FnMut(RpldocError),
-) -> Vec<DocExample> {
+pub(crate) fn load_examples(rpl_path: &Path, mut warn: impl FnMut(RpldocError)) -> Vec<DocExample> {
     let stem = match rpl_path.file_stem().and_then(|s| s.to_str()) {
         Some(s) => s,
         None => return Vec::new(),
@@ -30,9 +28,12 @@ pub(crate) fn load_examples(
     let mut entries: Vec<_> = match std::fs::read_dir(&dir) {
         Ok(rd) => rd.filter_map(Result::ok).collect(),
         Err(e) => {
-            warn(RpldocError::Io { path: dir.clone(), source: e });
+            warn(RpldocError::Io {
+                path: dir.clone(),
+                source: e,
+            });
             return Vec::new();
-        }
+        },
     };
     entries.sort_by_key(|e| e.file_name());
 
@@ -52,9 +53,12 @@ pub(crate) fn load_examples(
         let source = match std::fs::read_to_string(&path) {
             Ok(s) => s,
             Err(e) => {
-                warn(RpldocError::Io { path: path.clone(), source: e });
+                warn(RpldocError::Io {
+                    path: path.clone(),
+                    source: e,
+                });
                 continue;
-            }
+            },
         };
         out.push(promote_leading_inner_doc(filename, source));
     }
@@ -70,10 +74,7 @@ fn promote_leading_inner_doc(filename: String, source: String) -> DocExample {
         let trimmed = line.trim_end_matches('\n').trim_end_matches('\r');
         if trimmed.trim_start().starts_with("//!") {
             // Capture, stripping prefix and one optional space.
-            let after = trimmed
-                .trim_start()
-                .strip_prefix("//!")
-                .unwrap_or("");
+            let after = trimmed.trim_start().strip_prefix("//!").unwrap_or("");
             let stripped = after.strip_prefix(' ').unwrap_or(after);
             leading_doc.push(stripped.to_string());
             consumed_bytes += line.len();
@@ -107,8 +108,9 @@ fn promote_leading_inner_doc(filename: String, source: String) -> DocExample {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use std::fs;
+
+    use super::*;
 
     fn make_temp_with_layout(stem: &str, files: &[(&str, &str)]) -> tempfile::TempDir {
         let td = tempfile::TempDir::new().unwrap();
@@ -167,18 +169,12 @@ mod tests {
     fn promotes_leading_inner_doc_block() {
         let td = make_temp_with_layout(
             "Foo",
-            &[(
-                "a.rs",
-                "//! Demonstrates the bug.\n//! Second line.\n\nfn a() {}\n",
-            )],
+            &[("a.rs", "//! Demonstrates the bug.\n//! Second line.\n\nfn a() {}\n")],
         );
         let rpl = td.path().join("Foo.rpl");
         let examples = load_examples(&rpl, |_| {});
         assert_eq!(examples.len(), 1);
-        assert_eq!(
-            examples[0].leading_doc,
-            vec!["Demonstrates the bug.\nSecond line."]
-        );
+        assert_eq!(examples[0].leading_doc, vec!["Demonstrates the bug.\nSecond line."]);
         assert_eq!(examples[0].source, "fn a() {}\n");
     }
 

--- a/crates/rpl_doc/src/extract.rs
+++ b/crates/rpl_doc/src/extract.rs
@@ -125,11 +125,13 @@ mod dedent_tests {
 
 /// Build a `DocFile` from already-parsed `pairs::main`.
 ///
-/// Doesn't load examples (that's `examples::load_examples`'s job).
-pub(crate) fn build_doc_file(path: &Path, main: &pairs::main<'_>) -> DocFile {
+/// `source` is the original `.rpl` text — required so paragraph breaks
+/// (blank-line gaps between consecutive doc-comment spans) can be detected
+/// in `collect_runs`. Doesn't load examples (that's `examples::load_examples`'s job).
+pub(crate) fn build_doc_file<'i>(path: &Path, source: &'i str, main: &pairs::main<'i>) -> DocFile {
     let path = path.to_path_buf();
     let header_name = collect_header_name(main).to_string();
-    let file_doc = collect_file_doc(main);
+    let file_doc = collect_file_doc(main, source);
 
     let mut patterns = Vec::new();
     let mut utilities = Vec::new();
@@ -142,15 +144,15 @@ pub(crate) fn build_doc_file(path: &Path, main: &pairs::main<'_>) -> DocFile {
     for block in rpl_pattern.Block() {
         if let Some(patt) = block.pattBlock() {
             for item in patt.RPLPatternItem() {
-                patterns.push(build_doc_item(item));
+                patterns.push(build_doc_item(item, source));
             }
         } else if let Some(util) = block.utilBlock() {
             for item in util.RPLPatternItem() {
-                utilities.push(build_doc_item(item));
+                utilities.push(build_doc_item(item, source));
             }
         } else if let Some(d) = block.diagBlock() {
             for item in d.diagBlockItem() {
-                diagnostics.push(build_doc_diag(item));
+                diagnostics.push(build_doc_diag(item, source));
             }
         }
     }
@@ -171,9 +173,14 @@ pub(crate) fn build_doc_file(path: &Path, main: &pairs::main<'_>) -> DocFile {
 /// Grammar:
 ///   RPLPatternItem = OuterDocComment* ~ Attr* ~ Identifier
 ///                  ~ MetaVariableDeclList? ~ Assign ~ RustItemsOrPatternOperation
-fn build_doc_item(item: &pairs::RPLPatternItem<'_>) -> DocItem {
+fn build_doc_item<'i>(item: &pairs::RPLPatternItem<'i>, source: &'i str) -> DocItem {
     let outer_docs = item.OuterDocComment();
-    let doc = collect_runs(outer_docs.iter().map(|p| p.span.as_str()));
+    let doc = collect_runs(
+        outer_docs
+            .iter()
+            .map(|p| (p.span.start(), p.span.end(), p.span.as_str())),
+        source,
+    );
 
     let diag_attr = item.Attr().into_iter().find_map(extract_diag_attr_value);
 
@@ -202,9 +209,14 @@ fn build_doc_item(item: &pairs::RPLPatternItem<'_>) -> DocItem {
 ///                 ~ diagItems ~ MetaVariableWithDiagMessageSeparatedByComma? ~ RightBrace
 ///   diagItems     = diagItem ~ (Comma ~ diagItem)* ~ Comma?
 ///   diagItem      = Identifier ~ (LeftParen ~ diagAttrs ~ RightParen)? ~ Assign ~ diagMessage
-fn build_doc_diag(item: &pairs::diagBlockItem<'_>) -> DocDiag {
+fn build_doc_diag<'i>(item: &pairs::diagBlockItem<'i>, source: &'i str) -> DocDiag {
     let name = item.Identifier().span.as_str().to_string();
-    let doc = collect_runs(item.OuterDocComment().iter().map(|p| p.span.as_str()));
+    let doc = collect_runs(
+        item.OuterDocComment()
+            .iter()
+            .map(|p| (p.span.start(), p.span.end(), p.span.as_str())),
+        source,
+    );
 
     let mut primary = None;
     let mut label = None;
@@ -377,28 +389,53 @@ fn collect_header_name<'i>(main: &pairs::main<'i>) -> &'i str {
     rpl_header.Identifier().span.as_str()
 }
 
-fn collect_file_doc(main: &pairs::main<'_>) -> Vec<String> {
+fn collect_file_doc<'i>(main: &pairs::main<'i>, source: &'i str) -> Vec<String> {
     // `RPLPattern.InnerDocComment()` returns a `Vec<&InnerDocComment>` of
     // the zero-or-more inner doc lines that precede `RPLHeader`.
     let rpl_pattern = main.RPLPattern();
     let inner_docs = rpl_pattern.InnerDocComment();
-    collect_runs(inner_docs.iter().map(|p| p.span.as_str()))
+    collect_runs(
+        inner_docs
+            .iter()
+            .map(|p| (p.span.start(), p.span.end(), p.span.as_str())),
+        source,
+    )
 }
 
-/// Join doc-comment lines (with their `///` / `//!` prefix already stripped)
-/// into a single run separated by `\n`. Returns `Vec<String>` containing
-/// either zero or one run.
+/// Group prefix-stripped doc-comment lines into runs separated by blank lines
+/// in the original source.
 ///
-/// Why one run only: the strict-mode grammar forbids two doc-comment runs at
-/// the same attachment site (a blank line between them is a parse error), so
-/// the pest pairs we iterate are always one contiguous block.
-fn collect_runs<'a>(lines: impl Iterator<Item = &'a str>) -> Vec<String> {
-    let stripped: Vec<&str> = lines.map(strip_doc_prefix).collect();
-    if stripped.is_empty() {
-        Vec::new()
-    } else {
-        vec![stripped.join("\n")]
+/// `OuterDocComment*` in pest matches across blank lines because the implicit
+/// `WHITESPACE` rule consumes them. To preserve paragraph breaks in the
+/// rendered Markdown, we inspect the source-text gap between consecutive
+/// captured pairs: if the gap contains an empty line, we start a new run.
+///
+/// The renderer joins runs with `\n\n` (Markdown paragraph break), so each
+/// element of the returned Vec corresponds to one paragraph.
+fn collect_runs<'a>(spans: impl Iterator<Item = (usize, usize, &'a str)>, source: &'a str) -> Vec<String> {
+    let mut runs: Vec<Vec<&str>> = Vec::new();
+    let mut last_end: Option<usize> = None;
+    for (start, end, text) in spans {
+        let stripped = strip_doc_prefix(text);
+        let new_run = match last_end {
+            None => true,
+            Some(prev_end) => {
+                // The slice between the previous doc-comment line's end and
+                // this one's start contains whitespace (and possibly other
+                // comments). Count newlines: 2+ newlines means a blank line
+                // between them, which is a paragraph break.
+                let gap = &source[prev_end..start];
+                gap.matches('\n').count() >= 2
+            },
+        };
+        if new_run || runs.is_empty() {
+            runs.push(vec![stripped]);
+        } else {
+            runs.last_mut().unwrap().push(stripped);
+        }
+        last_end = Some(end);
     }
+    runs.into_iter().map(|r| r.join("\n")).collect()
 }
 
 #[cfg(test)]
@@ -415,7 +452,7 @@ mod build_tests {
     fn header_name_extracted() {
         let src = "pattern Foo\n";
         let main = parse(src);
-        let doc = build_doc_file(Path::new("/x/Foo.rpl"), &main);
+        let doc = build_doc_file(Path::new("/x/Foo.rpl"), src, &main);
         assert_eq!(doc.header_name, "Foo");
     }
 
@@ -423,7 +460,7 @@ mod build_tests {
     fn file_doc_empty_when_no_inner_doc() {
         let src = "pattern Foo\n";
         let main = parse(src);
-        let doc = build_doc_file(Path::new("/x/Foo.rpl"), &main);
+        let doc = build_doc_file(Path::new("/x/Foo.rpl"), src, &main);
         assert!(doc.file_doc.is_empty());
     }
 
@@ -435,7 +472,7 @@ mod build_tests {
 pattern Foo
 ";
         let main = parse(src);
-        let doc = build_doc_file(Path::new("/x/Foo.rpl"), &main);
+        let doc = build_doc_file(Path::new("/x/Foo.rpl"), src, &main);
         assert_eq!(doc.file_doc, vec!["first line\nsecond line".to_string()]);
     }
 
@@ -450,7 +487,7 @@ patt {
 }
 ";
         let main = parse(src);
-        let doc = build_doc_file(Path::new("/x/Foo.rpl"), &main);
+        let doc = build_doc_file(Path::new("/x/Foo.rpl"), src, &main);
         assert_eq!(doc.patterns.len(), 1);
         let item = &doc.patterns[0];
         assert_eq!(item.name, "p_foo");
@@ -469,7 +506,7 @@ patt {
 }
 ";
         let main = parse(src);
-        let doc = build_doc_file(Path::new("/x/Foo.rpl"), &main);
+        let doc = build_doc_file(Path::new("/x/Foo.rpl"), src, &main);
         assert_eq!(doc.patterns[0].meta_vars.as_deref(), Some("[$T: type]"));
     }
 
@@ -483,7 +520,7 @@ patt {
 }
 "#;
         let main = parse(src);
-        let doc = build_doc_file(Path::new("/x/Foo.rpl"), &main);
+        let doc = build_doc_file(Path::new("/x/Foo.rpl"), src, &main);
         assert_eq!(doc.patterns[0].diag_attr.as_deref(), Some("p_misordered"));
     }
 
@@ -496,7 +533,7 @@ util {
 }
 ";
         let main = parse(src);
-        let doc = build_doc_file(Path::new("/x/Foo.rpl"), &main);
+        let doc = build_doc_file(Path::new("/x/Foo.rpl"), src, &main);
         assert_eq!(doc.utilities.len(), 1);
         assert_eq!(doc.utilities[0].name, "u_foo");
         assert!(doc.patterns.is_empty());
@@ -515,7 +552,7 @@ patt {
 }
 "#;
         let main = parse(src);
-        let doc = build_doc_file(Path::new("/x/Foo.rpl"), &main);
+        let doc = build_doc_file(Path::new("/x/Foo.rpl"), src, &main);
         assert_eq!(doc.patterns.len(), 1);
         let body = &doc.patterns[0].body_source;
         assert!(body.contains("look: }"), "body lost the string content; got: {body:?}");
@@ -543,7 +580,7 @@ diag {
 }
 "#;
         let main = parse(src);
-        let doc = build_doc_file(Path::new("/x/Foo.rpl"), &main);
+        let doc = build_doc_file(Path::new("/x/Foo.rpl"), src, &main);
         assert_eq!(doc.diagnostics.len(), 1);
         let d = &doc.diagnostics[0];
         assert_eq!(d.name, "p_foo");
@@ -568,7 +605,7 @@ patt {
 }
 ";
         let main = parse(src);
-        let doc = build_doc_file(Path::new("/x/Foo.rpl"), &main);
+        let doc = build_doc_file(Path::new("/x/Foo.rpl"), src, &main);
         let mv = doc.patterns[0].meta_vars.as_deref().unwrap();
         // Newlines and indentation are collapsed; the heading becomes one line.
         assert!(!mv.contains('\n'));
@@ -589,8 +626,29 @@ patt {
 }
 "#;
         let main = parse(src);
-        let doc = build_doc_file(Path::new("/x/Foo.rpl"), &main);
+        let doc = build_doc_file(Path::new("/x/Foo.rpl"), src, &main);
         assert_eq!(doc.patterns.len(), 1);
         assert!(doc.patterns[0].diag_attr.is_none());
+    }
+
+    #[test]
+    fn blank_line_separates_paragraphs_in_doc() {
+        let src = "\
+pattern Foo
+patt {
+    /// First paragraph.
+
+    /// Second paragraph.
+    p_foo = fn _ (..) -> _ {
+        _ = const 0_usize;
+    }
+}
+";
+        let main = parse(src);
+        let doc = build_doc_file(Path::new("/x/Foo.rpl"), src, &main);
+        assert_eq!(
+            doc.patterns[0].doc,
+            vec!["First paragraph.".to_string(), "Second paragraph.".to_string()]
+        );
     }
 }

--- a/crates/rpl_doc/src/extract.rs
+++ b/crates/rpl_doc/src/extract.rs
@@ -43,3 +43,76 @@ mod tests {
         assert_eq!(strip_doc_prefix("//!"), "");
     }
 }
+
+/// Uniformly remove the smallest leading-whitespace prefix common to all
+/// non-blank lines. Blank lines are preserved as-is, and a trailing newline
+/// in the input is preserved in the output.
+///
+/// Used to "outdent" a pattern body so it doesn't carry the surrounding
+/// indentation into the rendered code block.
+pub(crate) fn dedent(text: &str) -> String {
+    let common = text
+        .lines()
+        .filter(|l| !l.trim().is_empty())
+        .map(|l| l.len() - l.trim_start().len())
+        .min()
+        .unwrap_or(0);
+
+    let mut out = String::with_capacity(text.len());
+    for (i, line) in text.lines().enumerate() {
+        if i > 0 {
+            out.push('\n');
+        }
+        if line.trim().is_empty() {
+            out.push_str(line);
+        } else {
+            out.push_str(&line[common..]);
+        }
+    }
+    // Preserve a trailing newline if the input had one — `str::lines()`
+    // does not yield a trailing empty element for `\n`-terminated input.
+    if text.ends_with('\n') {
+        out.push('\n');
+    }
+    out
+}
+
+#[cfg(test)]
+mod dedent_tests {
+    use super::*;
+
+    #[test]
+    fn dedents_uniform_block() {
+        let input = "    let a = 1;\n    let b = 2;";
+        assert_eq!(dedent(input), "let a = 1;\nlet b = 2;");
+    }
+
+    #[test]
+    fn preserves_relative_indentation() {
+        let input = "    if x {\n        y\n    }";
+        assert_eq!(dedent(input), "if x {\n    y\n}");
+    }
+
+    #[test]
+    fn ignores_blank_lines_when_computing_prefix() {
+        let input = "    a\n\n    b";
+        assert_eq!(dedent(input), "a\n\nb");
+    }
+
+    #[test]
+    fn returns_empty_for_empty_input() {
+        assert_eq!(dedent(""), "");
+    }
+
+    #[test]
+    fn preserves_trailing_newline() {
+        let input = "    a\n    b\n";
+        assert_eq!(dedent(input), "a\nb\n");
+    }
+
+    #[test]
+    fn no_trailing_newline_in_no_trailing_newline_out() {
+        let input = "    a\n    b";
+        assert_eq!(dedent(input), "a\nb");
+    }
+}

--- a/crates/rpl_doc/src/extract.rs
+++ b/crates/rpl_doc/src/extract.rs
@@ -184,7 +184,7 @@ fn build_doc_item<'i>(item: &pairs::RPLPatternItem<'i>) -> DocItem {
     let name = item.Identifier().span.as_str().to_string();
     let meta_vars = item
         .MetaVariableDeclList()
-        .map(|m| m.span.as_str().to_string());
+        .map(|m| collapse_whitespace(m.span.as_str()));
 
     let (signature, body_raw) = split_signature_and_body(item.RustItemsOrPatternOperation());
     let body_source = dedent(&body_raw);
@@ -359,6 +359,13 @@ fn split_signature_and_body<'i>(
         }
         None => (node_span.as_str().trim().to_string(), String::new()),
     }
+}
+
+/// Collapse all internal whitespace runs to single spaces.
+/// `"[$T: type,\n    $U: type,\n]"` → `"[$T: type, $U: type, ]"`.
+/// Used to normalize multi-line meta-var declarations into a one-line heading.
+fn collapse_whitespace(s: &str) -> String {
+    s.split_whitespace().collect::<Vec<_>>().join(" ")
 }
 
 /// Strip a single leading `\n` from `s` and strip all trailing whitespace
@@ -569,6 +576,26 @@ diag {
         assert_eq!(d.level.as_deref(), Some("deny"));
         assert_eq!(d.lint_name.as_deref(), Some("foo_lint"));
         assert!(d.note.is_none());
+    }
+
+    #[test]
+    fn multiline_meta_vars_collapsed_to_one_line() {
+        let src = "\
+pattern Foo
+patt {
+    p_foo[
+        $T: type,
+        $U: type,
+    ] = fn _ (..) -> _ { _ = const 0_usize; }
+}
+";
+        let main = parse(src);
+        let doc = build_doc_file(Path::new("/x/Foo.rpl"), &main);
+        let mv = doc.patterns[0].meta_vars.as_deref().unwrap();
+        // Newlines and indentation are collapsed; the heading becomes one line.
+        assert!(!mv.contains('\n'));
+        assert!(mv.contains("$T: type"));
+        assert!(mv.contains("$U: type"));
     }
 
     #[test]

--- a/crates/rpl_doc/src/extract.rs
+++ b/crates/rpl_doc/src/extract.rs
@@ -1,6 +1,6 @@
 //! Build `DocFile` from the typed pest AST.
 
-use crate::model::DocFile;
+use crate::model::{DocFile, DocItem};
 use rpl_parser::pairs;
 use std::path::Path;
 
@@ -132,15 +132,194 @@ pub(crate) fn build_doc_file<'i>(
     let header_name = collect_header_name(main).to_string();
     let file_doc = collect_file_doc(main);
 
+    let mut patterns = Vec::new();
+    let mut utilities = Vec::new();
+
+    // `RPLPattern.Block()` returns a `Vec<&Block>` of zero-or-more blocks.
+    // Each `Block` is a `Choice3` of `pattBlock | utilBlock | diagBlock`; the
+    // generated typed-pair API exposes one `Option<&_>` accessor per variant.
+    let rpl_pattern = main.RPLPattern();
+    for block in rpl_pattern.Block() {
+        if let Some(patt) = block.pattBlock() {
+            for item in patt.RPLPatternItem() {
+                patterns.push(build_doc_item(item));
+            }
+        } else if let Some(util) = block.utilBlock() {
+            for item in util.RPLPatternItem() {
+                utilities.push(build_doc_item(item));
+            }
+        }
+        // `diagBlock` is handled in a later task (C6).
+    }
+
     DocFile {
         path,
         header_name,
         file_doc,
-        patterns: Vec::new(),     // filled by later tasks
-        utilities: Vec::new(),    // filled by later tasks
-        diagnostics: Vec::new(),  // filled by later tasks
-        examples: Vec::new(),     // filled by examples::load_examples
+        patterns,
+        utilities,
+        diagnostics: Vec::new(), // filled by later tasks
+        examples: Vec::new(),    // filled by examples::load_examples
     }
+}
+
+/// Convert one `RPLPatternItem` into a `DocItem`.
+///
+/// Grammar:
+///   RPLPatternItem = OuterDocComment* ~ Attr* ~ Identifier
+///                  ~ MetaVariableDeclList? ~ Assign ~ RustItemsOrPatternOperation
+fn build_doc_item<'i>(item: &pairs::RPLPatternItem<'i>) -> DocItem {
+    let outer_docs = item.OuterDocComment();
+    let doc = collect_runs(outer_docs.iter().map(|p| p.span.as_str()));
+
+    let diag_attr = item
+        .Attr()
+        .into_iter()
+        .find_map(extract_diag_attr_value);
+
+    let name = item.Identifier().span.as_str().to_string();
+    let meta_vars = item
+        .MetaVariableDeclList()
+        .map(|m| m.span.as_str().to_string());
+
+    let (signature, body_raw) = split_signature_and_body(item.RustItemsOrPatternOperation());
+    let body_source = dedent(&body_raw);
+
+    DocItem {
+        name,
+        meta_vars,
+        doc,
+        diag_attr,
+        signature,
+        body_source,
+    }
+}
+
+/// If the given `Attr` is `#[diag = "value"]`, return `Some(value)` (the inner
+/// string without surrounding quotes). Otherwise return `None`.
+///
+/// Grammar:
+///   Attr      = Hash ~ LeftBracket ~ diagAttrs ~ RightBracket
+///   diagAttrs = diagAttr ~ (Comma ~ diagAttr)* ~ Comma?
+///   diagAttr  = Word ~ ((LeftParen ~ diagAttrs? ~ RightParen) | (Assign ~ diagMessage))?
+///   diagMessage = "\"" ~ diagMessageInner ~ "\""
+///
+/// The `Word` of the first `diagAttr` whose key is `diag` and which has an
+/// `Assign ~ diagMessage` form yields the value. `diagMessageInner` has its
+/// own span (Both-mode atomic), so its `span.as_str()` already excludes the
+/// surrounding quotes.
+fn extract_diag_attr_value<'i>(attr: &pairs::Attr<'i>) -> Option<String> {
+    let diag_attrs = attr.diagAttrs();
+    let (first, rest) = diag_attrs.diagAttr();
+    std::iter::once(first)
+        .chain(rest.into_iter())
+        .find_map(|da| {
+            if da.Word().span.as_str() == "diag" {
+                da.diagMessage()
+                    .map(|m| m.diagMessageInner().span.as_str().to_string())
+            } else {
+                None
+            }
+        })
+}
+
+/// Split a `RustItemsOrPatternOperation` into (signature, body), driven by
+/// the typed AST rather than byte-level brace counting.
+///
+/// Layout per variant:
+/// - `PatternOperation`: pure expression (e.g. `divergent[$T = $T]`). The
+///   entire text is the signature; there is no body.
+/// - `RustItemsWithConstraint` (`{ item+ }`): a wrapping brace block whose
+///   contents are several items. The signature is empty; the body is the
+///   text strictly between the outer `LeftBrace` and `RightBrace`.
+/// - `RustItemWithConstraint` (`Attr* ~ RustItem ~ WhereBlock?`): unwraps to
+///   one `RustItem` (`Fn`/`Struct`/`Enum`/`Impl`). The signature runs from
+///   the start of the node up to the item's opening brace, and the body is
+///   the text between that brace and its matching closer:
+///   - `Fn` with `LeftBrace ~ MirBody ~ RightBrace` body — use the `Fn`'s
+///     `FnBody` braces; for a `SemiColon`-only `FnBody`, the body is empty.
+///   - `Struct` / `Enum` / `Impl` — use their own `LeftBrace`/`RightBrace`
+///     accessors.
+///
+/// All brace positions come from named pest accessors, so a `}` (or `{`)
+/// inside a string literal (`const "..."`) never confuses the split — the
+/// previous byte-scan would have truncated the body at the first `}` inside
+/// a string. Body trimming uses `trim_start_matches('\n').trim_end_matches('\n')`
+/// to drop a leading and trailing newline without collapsing blank lines on
+/// either side.
+fn split_signature_and_body<'i>(
+    node: &pairs::RustItemsOrPatternOperation<'i>,
+) -> (String, String) {
+    // `PatternOperation` is an expression with no brace body.
+    if node.PatternOperation().is_some() {
+        return (node.span.as_str().trim().to_string(), String::new());
+    }
+
+    // `RustItemsWithConstraint` is `LeftBrace ~ RustItemWithConstraint+ ~
+    // RightBrace`. There is no signature; the body is the inside-of-braces.
+    if let Some(items) = node.RustItemsWithConstraint() {
+        let lb = items.LeftBrace().span;
+        let rb = items.RightBrace().span;
+        let input = lb.get_input();
+        let body = &input[lb.end()..rb.start()];
+        return (
+            String::new(),
+            trim_one_newline(body).to_string(),
+        );
+    }
+
+    // Otherwise: `RustItemWithConstraint` = `Attr* ~ RustItem ~ WhereBlock?`.
+    // Grammar guarantees one Choice3 arm matches; this `expect` only fires on
+    // a parser/grammar mismatch.
+    let item = node
+        .RustItemWithConstraint()
+        .expect("RustItemsOrPatternOperation must match one Choice3 variant");
+    let node_span = node.span;
+    let input = node_span.get_input();
+    let rust_item = item.RustItem();
+
+    // For each Rust item variant, locate the brace pair delimiting its body.
+    // `Fn` has the only variant whose body is optional (`SemiColon` form).
+    let braces = if let Some(f) = rust_item.Fn() {
+        let fn_body = f.FnBody();
+        match (fn_body.LeftBrace(), fn_body.RightBrace()) {
+            (Some(lb), Some(rb)) => Some((lb.span, rb.span)),
+            _ => None, // `SemiColon` form
+        }
+    } else if let Some(s) = rust_item.Struct() {
+        Some((s.LeftBrace().span, s.RightBrace().span))
+    } else if let Some(e) = rust_item.Enum() {
+        Some((e.LeftBrace().span, e.RightBrace().span))
+    } else if let Some(i) = rust_item.Impl() {
+        Some((i.LeftBrace().span, i.RightBrace().span))
+    } else {
+        // Grammar guarantees one RustItem variant matches; fall back safely.
+        None
+    };
+
+    match braces {
+        Some((lb, rb)) => {
+            let sig = &input[node_span.start()..lb.start()];
+            let body = &input[lb.end()..rb.start()];
+            (
+                sig.trim().to_string(),
+                trim_one_newline(body).to_string(),
+            )
+        }
+        None => (node_span.as_str().trim().to_string(), String::new()),
+    }
+}
+
+/// Strip a single leading and a single trailing `\n` from `s` (preserving any
+/// further consecutive newlines on either side).
+///
+/// `body_source` is later dedented; `dedent` preserves blank lines verbatim,
+/// so collapsing all leading/trailing newlines with `trim_matches('\n')`
+/// would silently lose intentional blank lines that the author wrote before
+/// or after the body content.
+fn trim_one_newline(s: &str) -> &str {
+    let s = s.strip_prefix('\n').unwrap_or(s);
+    s.strip_suffix('\n').unwrap_or(s)
 }
 
 fn collect_header_name<'i>(main: &pairs::main<'i>) -> &'i str {
@@ -214,5 +393,114 @@ pattern Foo
         let main = parse(src);
         let doc = build_doc_file(Path::new("/x/Foo.rpl"), &main);
         assert_eq!(doc.file_doc, vec!["first line\nsecond line".to_string()]);
+    }
+
+    #[test]
+    fn pattern_item_extracted() {
+        let src = "\
+pattern Foo
+patt {
+    /// docs for p_foo
+    /// continuation
+    p_foo = fn _ (..) -> _ { _ = const 0_usize; }
+}
+";
+        let main = parse(src);
+        let doc = build_doc_file(Path::new("/x/Foo.rpl"), &main);
+        assert_eq!(doc.patterns.len(), 1);
+        let item = &doc.patterns[0];
+        assert_eq!(item.name, "p_foo");
+        assert_eq!(item.doc, vec!["docs for p_foo\ncontinuation"]);
+        assert!(item.body_source.contains("_ = const 0_usize;"));
+        assert!(item.signature.contains("fn _"));
+        assert!(item.meta_vars.is_none());
+    }
+
+    #[test]
+    fn pattern_item_with_meta_vars() {
+        let src = "\
+pattern Foo
+patt {
+    p_foo[$T: type] = fn _ (..) -> _ { _ = const 0_usize; }
+}
+";
+        let main = parse(src);
+        let doc = build_doc_file(Path::new("/x/Foo.rpl"), &main);
+        assert_eq!(doc.patterns[0].meta_vars.as_deref(), Some("[$T: type]"));
+    }
+
+    #[test]
+    fn pattern_item_with_diag_attr() {
+        let src = r#"
+pattern Foo
+patt {
+    #[diag = "p_misordered"]
+    p_foo = fn _ (..) -> _ { _ = const 0_usize; }
+}
+"#;
+        let main = parse(src);
+        let doc = build_doc_file(Path::new("/x/Foo.rpl"), &main);
+        assert_eq!(doc.patterns[0].diag_attr.as_deref(), Some("p_misordered"));
+    }
+
+    #[test]
+    fn util_block_items_extracted() {
+        let src = "\
+pattern Foo
+util {
+    u_foo = fn _ (..) -> _ { _ = const 0_usize; }
+}
+";
+        let main = parse(src);
+        let doc = build_doc_file(Path::new("/x/Foo.rpl"), &main);
+        assert_eq!(doc.utilities.len(), 1);
+        assert_eq!(doc.utilities[0].name, "u_foo");
+        assert!(doc.patterns.is_empty());
+    }
+
+    #[test]
+    fn pattern_body_with_brace_in_string_literal_extracts_correctly() {
+        // Regression guard: `}` (or `{`) inside a `const "..."` string literal
+        // must not fool the signature/body split. A byte-level brace counter
+        // truncates the body at the inner `}`; the AST-driven split uses the
+        // typed span of the function's body braces and so sees through it.
+        let src = r#"
+pattern Foo
+patt {
+    p_foo = fn _ (..) -> _ { _ = const "look: }"; }
+}
+"#;
+        let main = parse(src);
+        let doc = build_doc_file(Path::new("/x/Foo.rpl"), &main);
+        assert_eq!(doc.patterns.len(), 1);
+        let body = &doc.patterns[0].body_source;
+        assert!(
+            body.contains("look: }"),
+            "body lost the string content; got: {body:?}"
+        );
+        // The trailing `;` must also survive — i.e. we did not stop at the
+        // `}` inside the literal.
+        assert!(
+            body.contains(';'),
+            "body truncated before the terminating `;`; got: {body:?}"
+        );
+    }
+
+    #[test]
+    fn non_diag_attr_is_silently_skipped() {
+        // The grammar accepts any `Word` as the attr key; we only consume
+        // `diag`. A non-`diag` key (e.g. `lint_level`) must not error or be
+        // misread as a diagnostic message.
+        let src = r#"
+pattern Foo
+patt {
+    #[lint_level = "deny"]
+    p_foo = fn _ (..) -> _ { _ = const 0_usize; }
+}
+"#;
+        let main = parse(src);
+        let doc = build_doc_file(Path::new("/x/Foo.rpl"), &main);
+        assert_eq!(doc.patterns.len(), 1);
+        assert!(doc.patterns[0].diag_attr.is_none());
     }
 }

--- a/crates/rpl_doc/src/extract.rs
+++ b/crates/rpl_doc/src/extract.rs
@@ -1,0 +1,45 @@
+//! Build `DocFile` from the typed pest AST.
+
+/// Strip the `///` or `//!` prefix and an optional single trailing space.
+///
+/// `/// foo`  → `foo`
+/// `///foo`   → `foo`
+/// `///  foo` → ` foo`  (extra leading space preserved)
+/// `//!`      → ``
+pub(crate) fn strip_doc_prefix(line: &str) -> &str {
+    let after_prefix = if let Some(rest) = line.strip_prefix("///") {
+        rest
+    } else if let Some(rest) = line.strip_prefix("//!") {
+        rest
+    } else {
+        line
+    };
+    after_prefix.strip_prefix(' ').unwrap_or(after_prefix)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn strips_outer_with_space() {
+        assert_eq!(strip_doc_prefix("/// foo"), "foo");
+    }
+    #[test]
+    fn strips_outer_without_space() {
+        assert_eq!(strip_doc_prefix("///foo"), "foo");
+    }
+    #[test]
+    fn preserves_extra_indentation() {
+        assert_eq!(strip_doc_prefix("///  foo"), " foo");
+    }
+    #[test]
+    fn strips_inner_with_space() {
+        assert_eq!(strip_doc_prefix("//! foo"), "foo");
+    }
+    #[test]
+    fn handles_empty_doc_comment() {
+        assert_eq!(strip_doc_prefix("///"), "");
+        assert_eq!(strip_doc_prefix("//!"), "");
+    }
+}

--- a/crates/rpl_doc/src/extract.rs
+++ b/crates/rpl_doc/src/extract.rs
@@ -361,16 +361,21 @@ fn split_signature_and_body<'i>(
     }
 }
 
-/// Strip a single leading and a single trailing `\n` from `s` (preserving any
-/// further consecutive newlines on either side).
+/// Strip a single leading `\n` from `s` and strip all trailing whitespace
+/// (spaces, tabs, and newlines) from `s`.
 ///
-/// `body_source` is later dedented; `dedent` preserves blank lines verbatim,
-/// so collapsing all leading/trailing newlines with `trim_matches('\n')`
-/// would silently lose intentional blank lines that the author wrote before
-/// or after the body content.
+/// The trailing-whitespace strip (rather than a single `\n`) is needed for
+/// multi-line bodies: the text between the opening `{` and closing `}` of
+/// `fn _ (..) -> _ {\n    body;\n}` ends with `\n    ` (the indentation
+/// before `}`), not a bare `\n`.  Stripping only `\n` leaves the trailing
+/// spaces intact, which then survive `dedent` as a whitespace-only line and
+/// end up as trailing spaces inside the rendered code block.
+///
+/// `dedent` preserves blank lines verbatim, so removing all trailing
+/// whitespace here does not affect intentional blank lines inside the body.
 fn trim_one_newline(s: &str) -> &str {
     let s = s.strip_prefix('\n').unwrap_or(s);
-    s.strip_suffix('\n').unwrap_or(s)
+    s.trim_end_matches(|c: char| c.is_ascii_whitespace())
 }
 
 fn collect_header_name<'i>(main: &pairs::main<'i>) -> &'i str {

--- a/crates/rpl_doc/src/extract.rs
+++ b/crates/rpl_doc/src/extract.rs
@@ -1,5 +1,9 @@
 //! Build `DocFile` from the typed pest AST.
 
+use crate::model::DocFile;
+use rpl_parser::pairs;
+use std::path::Path;
+
 /// Strip the `///` or `//!` prefix and an optional single trailing space.
 ///
 /// `/// foo`  → `foo`
@@ -114,5 +118,101 @@ mod dedent_tests {
     fn no_trailing_newline_in_no_trailing_newline_out() {
         let input = "    a\n    b";
         assert_eq!(dedent(input), "a\nb");
+    }
+}
+
+/// Build a `DocFile` from already-parsed `pairs::main`.
+///
+/// Doesn't load examples (that's `examples::load_examples`'s job).
+pub(crate) fn build_doc_file<'i>(
+    path: &Path,
+    main: &pairs::main<'i>,
+) -> DocFile {
+    let path = path.to_path_buf();
+    let header_name = collect_header_name(main).to_string();
+    let file_doc = collect_file_doc(main);
+
+    DocFile {
+        path,
+        header_name,
+        file_doc,
+        patterns: Vec::new(),     // filled by later tasks
+        utilities: Vec::new(),    // filled by later tasks
+        diagnostics: Vec::new(),  // filled by later tasks
+        examples: Vec::new(),     // filled by examples::load_examples
+    }
+}
+
+fn collect_header_name<'i>(main: &pairs::main<'i>) -> &'i str {
+    // Named accessors are immune to grammar shifts (e.g., a future
+    // file-level attribute prepended to `RPLPattern`). The generator emits
+    // one accessor per named child in the production:
+    //   main         → r#RPLPattern()
+    //   RPLPattern   → r#RPLHeader()
+    //   RPLHeader    → r#Identifier()
+    let rpl_pattern = main.RPLPattern();
+    let rpl_header = rpl_pattern.RPLHeader();
+    rpl_header.Identifier().span.as_str()
+}
+
+fn collect_file_doc<'i>(main: &pairs::main<'i>) -> Vec<String> {
+    // `RPLPattern.InnerDocComment()` returns a `Vec<&InnerDocComment>` of
+    // the zero-or-more inner doc lines that precede `RPLHeader`.
+    let rpl_pattern = main.RPLPattern();
+    let inner_docs = rpl_pattern.InnerDocComment();
+    collect_runs(inner_docs.iter().map(|p| p.span.as_str()))
+}
+
+/// Join doc-comment lines (with their `///` / `//!` prefix already stripped)
+/// into a single run separated by `\n`. Returns `Vec<String>` containing
+/// either zero or one run.
+///
+/// Why one run only: the strict-mode grammar forbids two doc-comment runs at
+/// the same attachment site (a blank line between them is a parse error), so
+/// the pest pairs we iterate are always one contiguous block.
+fn collect_runs<'a>(lines: impl Iterator<Item = &'a str>) -> Vec<String> {
+    let stripped: Vec<&str> = lines.map(strip_doc_prefix).collect();
+    if stripped.is_empty() {
+        Vec::new()
+    } else {
+        vec![stripped.join("\n")]
+    }
+}
+
+#[cfg(test)]
+mod build_tests {
+    use super::*;
+    use rpl_parser::parse_main;
+
+    fn parse(src: &str) -> pairs::main<'_> {
+        parse_main(src, Path::new("/synthetic/test.rpl")).expect("parse")
+    }
+
+    #[test]
+    fn header_name_extracted() {
+        let src = "pattern Foo\n";
+        let main = parse(src);
+        let doc = build_doc_file(Path::new("/x/Foo.rpl"), &main);
+        assert_eq!(doc.header_name, "Foo");
+    }
+
+    #[test]
+    fn file_doc_empty_when_no_inner_doc() {
+        let src = "pattern Foo\n";
+        let main = parse(src);
+        let doc = build_doc_file(Path::new("/x/Foo.rpl"), &main);
+        assert!(doc.file_doc.is_empty());
+    }
+
+    #[test]
+    fn file_doc_captured_when_inner_doc_present() {
+        let src = "\
+//! first line
+//! second line
+pattern Foo
+";
+        let main = parse(src);
+        let doc = build_doc_file(Path::new("/x/Foo.rpl"), &main);
+        assert_eq!(doc.file_doc, vec!["first line\nsecond line".to_string()]);
     }
 }

--- a/crates/rpl_doc/src/extract.rs
+++ b/crates/rpl_doc/src/extract.rs
@@ -1,8 +1,10 @@
 //! Build `DocFile` from the typed pest AST.
 
-use crate::model::{DocDiag, DocFile, DocItem};
-use rpl_parser::pairs;
 use std::path::Path;
+
+use rpl_parser::pairs;
+
+use crate::model::{DocDiag, DocFile, DocItem};
 
 /// Strip the `///` or `//!` prefix and an optional single trailing space.
 ///
@@ -124,10 +126,7 @@ mod dedent_tests {
 /// Build a `DocFile` from already-parsed `pairs::main`.
 ///
 /// Doesn't load examples (that's `examples::load_examples`'s job).
-pub(crate) fn build_doc_file<'i>(
-    path: &Path,
-    main: &pairs::main<'i>,
-) -> DocFile {
+pub(crate) fn build_doc_file(path: &Path, main: &pairs::main<'_>) -> DocFile {
     let path = path.to_path_buf();
     let header_name = collect_header_name(main).to_string();
     let file_doc = collect_file_doc(main);
@@ -172,14 +171,11 @@ pub(crate) fn build_doc_file<'i>(
 /// Grammar:
 ///   RPLPatternItem = OuterDocComment* ~ Attr* ~ Identifier
 ///                  ~ MetaVariableDeclList? ~ Assign ~ RustItemsOrPatternOperation
-fn build_doc_item<'i>(item: &pairs::RPLPatternItem<'i>) -> DocItem {
+fn build_doc_item(item: &pairs::RPLPatternItem<'_>) -> DocItem {
     let outer_docs = item.OuterDocComment();
     let doc = collect_runs(outer_docs.iter().map(|p| p.span.as_str()));
 
-    let diag_attr = item
-        .Attr()
-        .into_iter()
-        .find_map(extract_diag_attr_value);
+    let diag_attr = item.Attr().into_iter().find_map(extract_diag_attr_value);
 
     let name = item.Identifier().span.as_str().to_string();
     let meta_vars = item
@@ -206,7 +202,7 @@ fn build_doc_item<'i>(item: &pairs::RPLPatternItem<'i>) -> DocItem {
 ///                 ~ diagItems ~ MetaVariableWithDiagMessageSeparatedByComma? ~ RightBrace
 ///   diagItems     = diagItem ~ (Comma ~ diagItem)* ~ Comma?
 ///   diagItem      = Identifier ~ (LeftParen ~ diagAttrs ~ RightParen)? ~ Assign ~ diagMessage
-fn build_doc_diag<'i>(item: &pairs::diagBlockItem<'i>) -> DocDiag {
+fn build_doc_diag(item: &pairs::diagBlockItem<'_>) -> DocDiag {
     let name = item.Identifier().span.as_str().to_string();
     let doc = collect_runs(item.OuterDocComment().iter().map(|p| p.span.as_str()));
 
@@ -230,7 +226,7 @@ fn build_doc_diag<'i>(item: &pairs::diagBlockItem<'i>) -> DocDiag {
             "note" => note = Some(msg_text),
             "level" => level = Some(msg_text),
             "name" => lint_name = Some(msg_text),
-            _ => { /* unknown key — ignore */ }
+            _ => { /* unknown key — ignore */ },
         }
     }
 
@@ -259,38 +255,33 @@ fn build_doc_diag<'i>(item: &pairs::diagBlockItem<'i>) -> DocDiag {
 /// `Assign ~ diagMessage` form yields the value. `diagMessageInner` has its
 /// own span (Both-mode atomic), so its `span.as_str()` already excludes the
 /// surrounding quotes.
-fn extract_diag_attr_value<'i>(attr: &pairs::Attr<'i>) -> Option<String> {
+fn extract_diag_attr_value(attr: &pairs::Attr<'_>) -> Option<String> {
     let diag_attrs = attr.diagAttrs();
     let (first, rest) = diag_attrs.diagAttr();
-    std::iter::once(first)
-        .chain(rest.into_iter())
-        .find_map(|da| {
-            if da.Word().span.as_str() == "diag" {
-                da.diagMessage()
-                    .map(|m| m.diagMessageInner().span.as_str().to_string())
-            } else {
-                None
-            }
-        })
+    std::iter::once(first).chain(rest).find_map(|da| {
+        if da.Word().span.as_str() == "diag" {
+            da.diagMessage().map(|m| m.diagMessageInner().span.as_str().to_string())
+        } else {
+            None
+        }
+    })
 }
 
 /// Split a `RustItemsOrPatternOperation` into (signature, body), driven by
 /// the typed AST rather than byte-level brace counting.
 ///
 /// Layout per variant:
-/// - `PatternOperation`: pure expression (e.g. `divergent[$T = $T]`). The
-///   entire text is the signature; there is no body.
-/// - `RustItemsWithConstraint` (`{ item+ }`): a wrapping brace block whose
-///   contents are several items. The signature is empty; the body is the
-///   text strictly between the outer `LeftBrace` and `RightBrace`.
-/// - `RustItemWithConstraint` (`Attr* ~ RustItem ~ WhereBlock?`): unwraps to
-///   one `RustItem` (`Fn`/`Struct`/`Enum`/`Impl`). The signature runs from
-///   the start of the node up to the item's opening brace, and the body is
-///   the text between that brace and its matching closer:
-///   - `Fn` with `LeftBrace ~ MirBody ~ RightBrace` body — use the `Fn`'s
-///     `FnBody` braces; for a `SemiColon`-only `FnBody`, the body is empty.
-///   - `Struct` / `Enum` / `Impl` — use their own `LeftBrace`/`RightBrace`
-///     accessors.
+/// - `PatternOperation`: pure expression (e.g. `divergent[$T = $T]`). The entire text is the
+///   signature; there is no body.
+/// - `RustItemsWithConstraint` (`{ item+ }`): a wrapping brace block whose contents are several
+///   items. The signature is empty; the body is the text strictly between the outer `LeftBrace` and
+///   `RightBrace`.
+/// - `RustItemWithConstraint` (`Attr* ~ RustItem ~ WhereBlock?`): unwraps to one `RustItem`
+///   (`Fn`/`Struct`/`Enum`/`Impl`). The signature runs from the start of the node up to the item's
+///   opening brace, and the body is the text between that brace and its matching closer:
+///   - `Fn` with `LeftBrace ~ MirBody ~ RightBrace` body — use the `Fn`'s `FnBody` braces; for a
+///     `SemiColon`-only `FnBody`, the body is empty.
+///   - `Struct` / `Enum` / `Impl` — use their own `LeftBrace`/`RightBrace` accessors.
 ///
 /// All brace positions come from named pest accessors, so a `}` (or `{`)
 /// inside a string literal (`const "..."`) never confuses the split — the
@@ -298,9 +289,7 @@ fn extract_diag_attr_value<'i>(attr: &pairs::Attr<'i>) -> Option<String> {
 /// a string. Body trimming uses `trim_start_matches('\n').trim_end_matches('\n')`
 /// to drop a leading and trailing newline without collapsing blank lines on
 /// either side.
-fn split_signature_and_body<'i>(
-    node: &pairs::RustItemsOrPatternOperation<'i>,
-) -> (String, String) {
+fn split_signature_and_body(node: &pairs::RustItemsOrPatternOperation<'_>) -> (String, String) {
     // `PatternOperation` is an expression with no brace body.
     if node.PatternOperation().is_some() {
         return (node.span.as_str().trim().to_string(), String::new());
@@ -313,10 +302,7 @@ fn split_signature_and_body<'i>(
         let rb = items.RightBrace().span;
         let input = lb.get_input();
         let body = &input[lb.end()..rb.start()];
-        return (
-            String::new(),
-            trim_one_newline(body).to_string(),
-        );
+        return (String::new(), trim_one_newline(body).to_string());
     }
 
     // Otherwise: `RustItemWithConstraint` = `Attr* ~ RustItem ~ WhereBlock?`.
@@ -341,22 +327,16 @@ fn split_signature_and_body<'i>(
         Some((s.LeftBrace().span, s.RightBrace().span))
     } else if let Some(e) = rust_item.Enum() {
         Some((e.LeftBrace().span, e.RightBrace().span))
-    } else if let Some(i) = rust_item.Impl() {
-        Some((i.LeftBrace().span, i.RightBrace().span))
     } else {
-        // Grammar guarantees one RustItem variant matches; fall back safely.
-        None
+        rust_item.Impl().map(|i| (i.LeftBrace().span, i.RightBrace().span))
     };
 
     match braces {
         Some((lb, rb)) => {
             let sig = &input[node_span.start()..lb.start()];
             let body = &input[lb.end()..rb.start()];
-            (
-                sig.trim().to_string(),
-                trim_one_newline(body).to_string(),
-            )
-        }
+            (sig.trim().to_string(), trim_one_newline(body).to_string())
+        },
         None => (node_span.as_str().trim().to_string(), String::new()),
     }
 }
@@ -397,7 +377,7 @@ fn collect_header_name<'i>(main: &pairs::main<'i>) -> &'i str {
     rpl_header.Identifier().span.as_str()
 }
 
-fn collect_file_doc<'i>(main: &pairs::main<'i>) -> Vec<String> {
+fn collect_file_doc(main: &pairs::main<'_>) -> Vec<String> {
     // `RPLPattern.InnerDocComment()` returns a `Vec<&InnerDocComment>` of
     // the zero-or-more inner doc lines that precede `RPLHeader`.
     let rpl_pattern = main.RPLPattern();
@@ -423,8 +403,9 @@ fn collect_runs<'a>(lines: impl Iterator<Item = &'a str>) -> Vec<String> {
 
 #[cfg(test)]
 mod build_tests {
-    use super::*;
     use rpl_parser::parse_main;
+
+    use super::*;
 
     fn parse(src: &str) -> pairs::main<'_> {
         parse_main(src, Path::new("/synthetic/test.rpl")).expect("parse")
@@ -537,10 +518,7 @@ patt {
         let doc = build_doc_file(Path::new("/x/Foo.rpl"), &main);
         assert_eq!(doc.patterns.len(), 1);
         let body = &doc.patterns[0].body_source;
-        assert!(
-            body.contains("look: }"),
-            "body lost the string content; got: {body:?}"
-        );
+        assert!(body.contains("look: }"), "body lost the string content; got: {body:?}");
         // The trailing `;` must also survive — i.e. we did not stop at the
         // `}` inside the literal.
         assert!(

--- a/crates/rpl_doc/src/extract.rs
+++ b/crates/rpl_doc/src/extract.rs
@@ -1,6 +1,6 @@
 //! Build `DocFile` from the typed pest AST.
 
-use crate::model::{DocFile, DocItem};
+use crate::model::{DocDiag, DocFile, DocItem};
 use rpl_parser::pairs;
 use std::path::Path;
 
@@ -134,6 +134,7 @@ pub(crate) fn build_doc_file<'i>(
 
     let mut patterns = Vec::new();
     let mut utilities = Vec::new();
+    let mut diagnostics = Vec::new();
 
     // `RPLPattern.Block()` returns a `Vec<&Block>` of zero-or-more blocks.
     // Each `Block` is a `Choice3` of `pattBlock | utilBlock | diagBlock`; the
@@ -148,8 +149,11 @@ pub(crate) fn build_doc_file<'i>(
             for item in util.RPLPatternItem() {
                 utilities.push(build_doc_item(item));
             }
+        } else if let Some(d) = block.diagBlock() {
+            for item in d.diagBlockItem() {
+                diagnostics.push(build_doc_diag(item));
+            }
         }
-        // `diagBlock` is handled in a later task (C6).
     }
 
     DocFile {
@@ -158,8 +162,8 @@ pub(crate) fn build_doc_file<'i>(
         file_doc,
         patterns,
         utilities,
-        diagnostics: Vec::new(), // filled by later tasks
-        examples: Vec::new(),    // filled by examples::load_examples
+        diagnostics,
+        examples: Vec::new(), // filled by examples::load_examples
     }
 }
 
@@ -192,6 +196,53 @@ fn build_doc_item<'i>(item: &pairs::RPLPatternItem<'i>) -> DocItem {
         diag_attr,
         signature,
         body_source,
+    }
+}
+
+/// Convert one `diagBlockItem` into a `DocDiag`.
+///
+/// Grammar:
+///   diagBlockItem = OuterDocComment* ~ Identifier ~ Assign ~ LeftBrace
+///                 ~ diagItems ~ MetaVariableWithDiagMessageSeparatedByComma? ~ RightBrace
+///   diagItems     = diagItem ~ (Comma ~ diagItem)* ~ Comma?
+///   diagItem      = Identifier ~ (LeftParen ~ diagAttrs ~ RightParen)? ~ Assign ~ diagMessage
+fn build_doc_diag<'i>(item: &pairs::diagBlockItem<'i>) -> DocDiag {
+    let name = item.Identifier().span.as_str().to_string();
+    let doc = collect_runs(item.OuterDocComment().iter().map(|p| p.span.as_str()));
+
+    let mut primary = None;
+    let mut label = None;
+    let mut help = None;
+    let mut note = None;
+    let mut level = None;
+    let mut lint_name = None;
+
+    // `diagItems().diagItem()` returns a head-tail tuple
+    // `(&diagItem, Vec<&diagItem>)` — same shape as `diagAttrs.diagAttr()`.
+    let (first, rest) = item.diagItems().diagItem();
+    for di in std::iter::once(first).chain(rest.into_iter()) {
+        let key = di.Identifier().span.as_str();
+        let msg_text = di.diagMessage().diagMessageInner().span.as_str().to_string();
+        match key {
+            "primary" => primary = Some(msg_text),
+            "label" => label = Some(msg_text),
+            "help" => help = Some(msg_text),
+            "note" => note = Some(msg_text),
+            "level" => level = Some(msg_text),
+            "name" => lint_name = Some(msg_text),
+            _ => { /* unknown key — ignore */ }
+        }
+    }
+
+    DocDiag {
+        name,
+        doc,
+        primary,
+        label,
+        help,
+        note,
+        level,
+        lint_name,
     }
 }
 
@@ -484,6 +535,35 @@ patt {
             body.contains(';'),
             "body truncated before the terminating `;`; got: {body:?}"
         );
+    }
+
+    #[test]
+    fn diag_item_extracted() {
+        let src = r#"
+pattern Foo
+diag {
+    /// detection notes
+    p_foo = {
+        primary(span) = "primary text",
+        label(span) = "label text",
+        help(span) = "help text",
+        level = "deny",
+        name = "foo_lint",
+    }
+}
+"#;
+        let main = parse(src);
+        let doc = build_doc_file(Path::new("/x/Foo.rpl"), &main);
+        assert_eq!(doc.diagnostics.len(), 1);
+        let d = &doc.diagnostics[0];
+        assert_eq!(d.name, "p_foo");
+        assert_eq!(d.doc, vec!["detection notes"]);
+        assert_eq!(d.primary.as_deref(), Some("primary text"));
+        assert_eq!(d.label.as_deref(), Some("label text"));
+        assert_eq!(d.help.as_deref(), Some("help text"));
+        assert_eq!(d.level.as_deref(), Some("deny"));
+        assert_eq!(d.lint_name.as_deref(), Some("foo_lint"));
+        assert!(d.note.is_none());
     }
 
     #[test]

--- a/crates/rpl_doc/src/lib.rs
+++ b/crates/rpl_doc/src/lib.rs
@@ -75,7 +75,7 @@ pub fn render_markdown(rpl_path: &std::path::Path) -> Result<String, RpldocError
         path: rpl_path.to_path_buf(),
         message: format!("{e}"),
     })?;
-    let mut doc = extract::build_doc_file(rpl_path, &main);
+    let mut doc = extract::build_doc_file(rpl_path, &source, &main);
     if doc.header_name.is_empty() {
         return Err(RpldocError::MissingPatternHeader {
             path: rpl_path.to_path_buf(),
@@ -97,6 +97,19 @@ pub fn run_cli(path: &std::path::Path, opts: GenerateOpts) -> Result<(), Vec<Rpl
     let files: Vec<std::path::PathBuf> = if path.is_dir() {
         walkdir::WalkDir::new(path)
             .into_iter()
+            .filter_entry(|e| {
+                let name = e.file_name().to_string_lossy();
+                // Skip hidden entries except the root (which can be "." or
+                // have a "." prefix legitimately).
+                if e.depth() > 0 && name.starts_with('.') {
+                    return false;
+                }
+                // Skip cargo build output.
+                if e.file_type().is_dir() && name == "target" {
+                    return false;
+                }
+                true
+            })
             .filter_map(Result::ok)
             .filter(|e| e.file_type().is_file())
             .filter(|e| e.path().extension().and_then(|s| s.to_str()) == Some("rpl"))

--- a/crates/rpl_doc/src/lib.rs
+++ b/crates/rpl_doc/src/lib.rs
@@ -10,6 +10,8 @@ pub use error::RpldocError;
 pub mod model;
 pub use model::{DocDiag, DocExample, DocFile, DocItem};
 
+mod extract;
+
 use std::path::Path;
 
 /// Parse an `.rpl` source string through the rpl_parser pipeline.

--- a/crates/rpl_doc/src/lib.rs
+++ b/crates/rpl_doc/src/lib.rs
@@ -2,13 +2,40 @@
 //!
 //! See `docs/superpowers/specs/2026-05-26-rpldoc-design.md` for the design.
 
+pub mod error;
+pub use error::RpldocError;
+
 /// Crate version, exposed for sanity tests.
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
     #[test]
     fn crate_loads() {
-        assert!(!super::VERSION.is_empty());
+        assert!(!VERSION.is_empty());
+    }
+
+    #[test]
+    fn missing_pattern_header_error_renders() {
+        let err = RpldocError::MissingPatternHeader {
+            path: PathBuf::from("/tmp/foo.rpl"),
+        };
+        let msg = format!("{err}");
+        assert!(msg.contains("foo.rpl"));
+        assert!(msg.contains("pattern"));
+    }
+
+    #[test]
+    fn io_error_renders() {
+        let err = RpldocError::Io {
+            path: PathBuf::from("/tmp/foo.rpl"),
+            source: std::io::Error::new(std::io::ErrorKind::NotFound, "not found"),
+        };
+        let msg = format!("{err}");
+        assert!(msg.contains("foo.rpl"));
+        assert!(msg.contains("not found"));
     }
 }

--- a/crates/rpl_doc/src/lib.rs
+++ b/crates/rpl_doc/src/lib.rs
@@ -90,6 +90,74 @@ pub fn render_markdown(rpl_path: &std::path::Path) -> Result<String, RpldocError
     Ok(render::render(&doc))
 }
 
+/// Drive the CLI: takes a `PATH` (file or directory) and writes Markdown
+/// outputs. Returns `Ok(())` if everything succeeded, or a `Vec` of all
+/// per-file errors (and exits 1 in the caller).
+pub fn run_cli(path: &std::path::Path, opts: GenerateOpts) -> Result<(), Vec<RpldocError>> {
+    let mut errors = Vec::new();
+    let files: Vec<std::path::PathBuf> = if path.is_dir() {
+        walkdir::WalkDir::new(path)
+            .into_iter()
+            .filter_map(Result::ok)
+            .filter(|e| e.file_type().is_file())
+            .filter(|e| e.path().extension().and_then(|s| s.to_str()) == Some("rpl"))
+            .map(|e| e.into_path())
+            .collect()
+    } else {
+        vec![path.to_path_buf()]
+    };
+
+    for rpl in &files {
+        let md = match render_markdown(rpl) {
+            Ok(md) => md,
+            Err(e) => {
+                errors.push(e);
+                continue;
+            }
+        };
+        let out_path = compute_output_path(path, rpl, &opts);
+        if let Some(parent) = out_path.parent() {
+            if let Err(e) = std::fs::create_dir_all(parent) {
+                errors.push(RpldocError::OutputWrite {
+                    path: parent.to_path_buf(),
+                    source: e,
+                });
+                continue;
+            }
+        }
+        if let Err(e) = std::fs::write(&out_path, &md) {
+            errors.push(RpldocError::OutputWrite { path: out_path.clone(), source: e });
+            continue;
+        }
+        if !opts.quiet {
+            eprintln!("generated {}", out_path.display());
+        }
+    }
+
+    if errors.is_empty() { Ok(()) } else { Err(errors) }
+}
+
+fn compute_output_path(
+    input_root: &std::path::Path,
+    rpl: &std::path::Path,
+    opts: &GenerateOpts,
+) -> std::path::PathBuf {
+    match &opts.output_root {
+        None => rpl.with_extension("md"),
+        Some(out_root) => {
+            // Mirror the rpl's path relative to input_root under out_root.
+            let rel = if input_root.is_file() {
+                std::path::PathBuf::from(rpl.file_name().unwrap_or_default())
+            } else {
+                rpl.strip_prefix(input_root)
+                    .map(|p| p.to_path_buf())
+                    .unwrap_or_else(|_| std::path::PathBuf::from(rpl.file_name().unwrap_or_default()))
+            };
+            out_root.join(rel).with_extension("md")
+        }
+    }
+}
+
 /// Crate version, exposed for sanity tests.
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");
 

--- a/crates/rpl_doc/src/lib.rs
+++ b/crates/rpl_doc/src/lib.rs
@@ -10,6 +10,7 @@ pub use error::RpldocError;
 pub mod model;
 pub use model::{DocDiag, DocExample, DocFile, DocItem};
 
+mod examples;
 mod extract;
 
 use std::path::Path;

--- a/crates/rpl_doc/src/lib.rs
+++ b/crates/rpl_doc/src/lib.rs
@@ -1,0 +1,14 @@
+//! rpldoc — generate Markdown documentation from .rpl pattern files.
+//!
+//! See `docs/superpowers/specs/2026-05-26-rpldoc-design.md` for the design.
+
+/// Crate version, exposed for sanity tests.
+pub const VERSION: &str = env!("CARGO_PKG_VERSION");
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn crate_loads() {
+        assert!(!super::VERSION.is_empty());
+    }
+}

--- a/crates/rpl_doc/src/lib.rs
+++ b/crates/rpl_doc/src/lib.rs
@@ -50,6 +50,46 @@ mod model_tests {
     }
 }
 
+/// Options controlling output behavior.
+#[derive(Debug, Clone, Default)]
+pub struct GenerateOpts {
+    /// Optional output base directory. If `None`, write the .md next to each .rpl.
+    /// If `Some`, write outputs under this directory, mirroring the input tree
+    /// rooted at the input PATH.
+    pub output_root: Option<std::path::PathBuf>,
+    /// Suppress per-file "Generated foo.md" status lines.
+    pub quiet: bool,
+}
+
+/// Build the documentation Markdown for a single `.rpl` file and return it.
+///
+/// This is the in-memory entry point — the CLI calls this and writes the
+/// returned string to disk.
+pub fn render_markdown(rpl_path: &std::path::Path) -> Result<String, RpldocError> {
+    let source = std::fs::read_to_string(rpl_path).map_err(|e| RpldocError::Io {
+        path: rpl_path.to_path_buf(),
+        source: e,
+    })?;
+    let main = rpl_parser::parse_main(&source, rpl_path).map_err(|e| {
+        RpldocError::Parse {
+            path: rpl_path.to_path_buf(),
+            message: format!("{e}"),
+        }
+    })?;
+    let mut doc = extract::build_doc_file(rpl_path, &main);
+    if doc.header_name.is_empty() {
+        return Err(RpldocError::MissingPatternHeader {
+            path: rpl_path.to_path_buf(),
+        });
+    }
+    let mut warnings: Vec<RpldocError> = Vec::new();
+    doc.examples = examples::load_examples(rpl_path, |w| warnings.push(w));
+    for w in warnings {
+        eprintln!("warning: {w}");
+    }
+    Ok(render::render(&doc))
+}
+
 /// Crate version, exposed for sanity tests.
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");
 
@@ -104,5 +144,32 @@ mod tests {
         let msg = format!("{err}");
         assert!(msg.contains("foo.rpl"));
         assert!(msg.contains("not found"));
+    }
+}
+
+#[cfg(test)]
+mod render_markdown_tests {
+    use super::*;
+
+    fn write(td: &tempfile::TempDir, name: &str, content: &str) -> std::path::PathBuf {
+        let p = td.path().join(name);
+        std::fs::write(&p, content).unwrap();
+        p
+    }
+
+    #[test]
+    fn renders_minimal_pattern() {
+        let td = tempfile::TempDir::new().unwrap();
+        let p = write(&td, "Foo.rpl", "pattern Foo\n");
+        let md = render_markdown(&p).unwrap();
+        assert_eq!(md, "# Foo\n\n");
+    }
+
+    #[test]
+    fn parse_error_propagates_as_rpldoc_error() {
+        let td = tempfile::TempDir::new().unwrap();
+        let p = write(&td, "Bad.rpl", "not a pattern at all\n");
+        let err = render_markdown(&p).unwrap_err();
+        assert!(matches!(err, RpldocError::Parse { .. }));
     }
 }

--- a/crates/rpl_doc/src/lib.rs
+++ b/crates/rpl_doc/src/lib.rs
@@ -2,11 +2,51 @@
 //!
 //! See `docs/superpowers/specs/2026-05-26-rpldoc-design.md` for the design.
 
+#![feature(rustc_private)]
+
 pub mod error;
 pub use error::RpldocError;
 
+use std::path::Path;
+
+/// Parse an `.rpl` source string through the rpl_parser pipeline.
+///
+/// Returns `Ok(())` if parsing succeeds. The typed AST is dropped — callers
+/// that want it should use `rpl_parser::parse_main` directly. This is the
+/// minimal entry point for the corpus-sweep backward-compatibility gate.
+pub fn parse_only(path: &Path, source: &str) -> Result<(), RpldocError> {
+    rpl_parser::parse_main(source, path).map(|_| ()).map_err(|e| {
+        RpldocError::Parse {
+            path: path.to_path_buf(),
+            message: format!("{e}"),
+        }
+    })
+}
+
 /// Crate version, exposed for sanity tests.
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");
+
+#[cfg(test)]
+mod parse_only_tests {
+    use super::*;
+    use std::path::Path;
+
+    #[test]
+    fn parse_only_accepts_simple_pattern_file() {
+        let src = "pattern Foo\n";
+        // parse_only does not need the path to exist on disk; only used in errors.
+        let result = parse_only(Path::new("/synthetic/foo.rpl"), src);
+        assert!(result.is_ok(), "expected Ok, got {result:?}");
+    }
+
+    #[test]
+    fn parse_only_reports_parse_error() {
+        // `paten` is a misspelling of `pattern` — parse failure expected.
+        let src = "paten Foo\n";
+        let result = parse_only(Path::new("/synthetic/foo.rpl"), src);
+        assert!(result.is_err());
+    }
+}
 
 #[cfg(test)]
 mod tests {

--- a/crates/rpl_doc/src/lib.rs
+++ b/crates/rpl_doc/src/lib.rs
@@ -7,6 +7,9 @@
 pub mod error;
 pub use error::RpldocError;
 
+pub mod model;
+pub use model::{DocDiag, DocExample, DocFile, DocItem};
+
 use std::path::Path;
 
 /// Parse an `.rpl` source string through the rpl_parser pipeline.
@@ -21,6 +24,26 @@ pub fn parse_only(path: &Path, source: &str) -> Result<(), RpldocError> {
             message: format!("{e}"),
         }
     })
+}
+
+#[cfg(test)]
+mod model_tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    #[test]
+    fn doc_file_constructs() {
+        let f = DocFile {
+            path: PathBuf::from("/x.rpl"),
+            header_name: "X".into(),
+            file_doc: vec!["hello".into()],
+            patterns: vec![],
+            utilities: vec![],
+            diagnostics: vec![],
+            examples: vec![],
+        };
+        assert_eq!(f.header_name, "X");
+    }
 }
 
 /// Crate version, exposed for sanity tests.

--- a/crates/rpl_doc/src/lib.rs
+++ b/crates/rpl_doc/src/lib.rs
@@ -22,18 +22,19 @@ use std::path::Path;
 /// that want it should use `rpl_parser::parse_main` directly. This is the
 /// minimal entry point for the corpus-sweep backward-compatibility gate.
 pub fn parse_only(path: &Path, source: &str) -> Result<(), RpldocError> {
-    rpl_parser::parse_main(source, path).map(|_| ()).map_err(|e| {
-        RpldocError::Parse {
+    rpl_parser::parse_main(source, path)
+        .map(|_| ())
+        .map_err(|e| RpldocError::Parse {
             path: path.to_path_buf(),
             message: format!("{e}"),
-        }
-    })
+        })
 }
 
 #[cfg(test)]
 mod model_tests {
-    use super::*;
     use std::path::PathBuf;
+
+    use super::*;
 
     #[test]
     fn doc_file_constructs() {
@@ -70,11 +71,9 @@ pub fn render_markdown(rpl_path: &std::path::Path) -> Result<String, RpldocError
         path: rpl_path.to_path_buf(),
         source: e,
     })?;
-    let main = rpl_parser::parse_main(&source, rpl_path).map_err(|e| {
-        RpldocError::Parse {
-            path: rpl_path.to_path_buf(),
-            message: format!("{e}"),
-        }
+    let main = rpl_parser::parse_main(&source, rpl_path).map_err(|e| RpldocError::Parse {
+        path: rpl_path.to_path_buf(),
+        message: format!("{e}"),
     })?;
     let mut doc = extract::build_doc_file(rpl_path, &main);
     if doc.header_name.is_empty() {
@@ -113,7 +112,7 @@ pub fn run_cli(path: &std::path::Path, opts: GenerateOpts) -> Result<(), Vec<Rpl
             Err(e) => {
                 errors.push(e);
                 continue;
-            }
+            },
         };
         let out_path = compute_output_path(path, rpl, &opts);
         if let Some(parent) = out_path.parent() {
@@ -126,7 +125,10 @@ pub fn run_cli(path: &std::path::Path, opts: GenerateOpts) -> Result<(), Vec<Rpl
             }
         }
         if let Err(e) = std::fs::write(&out_path, &md) {
-            errors.push(RpldocError::OutputWrite { path: out_path.clone(), source: e });
+            errors.push(RpldocError::OutputWrite {
+                path: out_path.clone(),
+                source: e,
+            });
             continue;
         }
         if !opts.quiet {
@@ -137,11 +139,7 @@ pub fn run_cli(path: &std::path::Path, opts: GenerateOpts) -> Result<(), Vec<Rpl
     if errors.is_empty() { Ok(()) } else { Err(errors) }
 }
 
-fn compute_output_path(
-    input_root: &std::path::Path,
-    rpl: &std::path::Path,
-    opts: &GenerateOpts,
-) -> std::path::PathBuf {
+fn compute_output_path(input_root: &std::path::Path, rpl: &std::path::Path, opts: &GenerateOpts) -> std::path::PathBuf {
     match &opts.output_root {
         None => rpl.with_extension("md"),
         Some(out_root) => {
@@ -154,7 +152,7 @@ fn compute_output_path(
                     .unwrap_or_else(|_| std::path::PathBuf::from(rpl.file_name().unwrap_or_default()))
             };
             out_root.join(rel).with_extension("md")
-        }
+        },
     }
 }
 
@@ -163,8 +161,9 @@ pub const VERSION: &str = env!("CARGO_PKG_VERSION");
 
 #[cfg(test)]
 mod parse_only_tests {
-    use super::*;
     use std::path::Path;
+
+    use super::*;
 
     #[test]
     fn parse_only_accepts_simple_pattern_file() {
@@ -185,13 +184,9 @@ mod parse_only_tests {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use std::path::PathBuf;
 
-    #[test]
-    fn crate_loads() {
-        assert!(!VERSION.is_empty());
-    }
+    use super::*;
 
     #[test]
     fn missing_pattern_header_error_renders() {

--- a/crates/rpl_doc/src/lib.rs
+++ b/crates/rpl_doc/src/lib.rs
@@ -12,6 +12,7 @@ pub use model::{DocDiag, DocExample, DocFile, DocItem};
 
 mod examples;
 mod extract;
+mod render;
 
 use std::path::Path;
 

--- a/crates/rpl_doc/src/model.rs
+++ b/crates/rpl_doc/src/model.rs
@@ -1,0 +1,83 @@
+//! Plain-data types describing an rpldoc-parsed pattern file.
+//!
+//! These types are constructed by `extract.rs` from the typed pest AST and
+//! consumed by `render.rs` to emit Markdown.
+
+use std::path::PathBuf;
+
+/// The top-level documentation extracted from a single `.rpl` file.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DocFile {
+    /// Source path. Used in errors and to derive output path / examples folder.
+    pub path: PathBuf,
+    /// Name from `pattern <Name>`.
+    pub header_name: String,
+    /// File-level `//!` content, split into runs. Each `Vec<String>` element
+    /// is one run; lines within a run are joined with `\n` at render time.
+    pub file_doc: Vec<String>,
+    /// Items from any `patt` block(s).
+    pub patterns: Vec<DocItem>,
+    /// Items from any `util` block(s).
+    pub utilities: Vec<DocItem>,
+    /// Items from any `diag` block(s).
+    pub diagnostics: Vec<DocDiag>,
+    /// Sibling-folder `.rs` files, lex-ordered.
+    pub examples: Vec<DocExample>,
+}
+
+/// A pattern or util item: `[/// docs]* [#[attr]]* name [meta_vars] = body`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DocItem {
+    /// Identifier — e.g. `p_u8_to_t_misordered_para_inline`.
+    pub name: String,
+    /// Bracketed meta-var list source text — e.g. `[$T: type]`. `None` if absent.
+    pub meta_vars: Option<String>,
+    /// Attached `///` content, prefix-stripped. Each element is one source
+    /// line; the renderer joins them with `\n`. Empty `Vec` when no doc is
+    /// attached. Stored as `Vec<String>` (not `Option<String>`) so future
+    /// blank-line-broken multi-run support can land without an API change.
+    pub doc: Vec<String>,
+    /// Value of an `#[diag = "..."]` attribute, if present.
+    pub diag_attr: Option<String>,
+    /// Item signature — text from `=` up to the body's opening brace.
+    /// Example: `unsafe? fn _ (..) -> _`.
+    pub signature: String,
+    /// Body text between matching `{` and `}`, uniformly dedented.
+    pub body_source: String,
+}
+
+/// A diagnostic group: `[/// docs]* name = { fields... }`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DocDiag {
+    /// Diagnostic identifier — the LHS of `<name> = { ... }` in the diag block.
+    pub name: String,
+    /// Attached `///` content, prefix-stripped. Each element is one source
+    /// line; the renderer joins them with `\n`. Empty `Vec` when no doc is
+    /// attached. Stored as `Vec<String>` (not `Option<String>`) so future
+    /// blank-line-broken multi-run support can land without an API change.
+    pub doc: Vec<String>,
+    /// Primary message text from `primary(span) = "..."`.
+    pub primary: Option<String>,
+    /// Span label text from `label(span) = "..."`.
+    pub label: Option<String>,
+    /// Help text from `help(span) = "..."`.
+    pub help: Option<String>,
+    /// Supplemental note text from `note(span) = "..."`.
+    pub note: Option<String>,
+    /// Severity from `level = "..."` — typically `"deny"`, `"warn"`, or `"allow"`.
+    pub level: Option<String>,
+    /// User-visible lint name from `name = "..."` — appears in compiler output.
+    pub lint_name: Option<String>,
+}
+
+/// An example .rs file from the sibling folder.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DocExample {
+    /// Bare filename (e.g. `"basic.rs"`) — no directory component.
+    pub filename: String,
+    /// `//!` block at the top of the file, prefix-stripped, if any.
+    /// Each element is one source line; renderer joins with `\n`.
+    pub leading_doc: Vec<String>,
+    /// Source text with the leading `//!` block removed.
+    pub source: String,
+}

--- a/crates/rpl_doc/src/render.rs
+++ b/crates/rpl_doc/src/render.rs
@@ -1,0 +1,68 @@
+//! Render `DocFile` to Markdown.
+
+use crate::model::{DocDiag, DocExample, DocFile, DocItem};
+
+/// For a given block of text that will be wrapped in a backtick fence,
+/// return the fence length to use. Always >= 3, and strictly longer than
+/// any run of backticks inside `body`.
+pub(crate) fn fence_len_for(body: &str) -> usize {
+    let mut max_run = 0usize;
+    let mut cur = 0usize;
+    for c in body.chars() {
+        if c == '`' {
+            cur += 1;
+            if cur > max_run {
+                max_run = cur;
+            }
+        } else {
+            cur = 0;
+        }
+    }
+    std::cmp::max(3, max_run + 1)
+}
+
+/// Helper: write a fenced code block to `out`, escalating the fence length
+/// as needed to safely embed `body`.
+pub(crate) fn write_fence(out: &mut String, lang: &str, body: &str) {
+    let n = fence_len_for(body);
+    for _ in 0..n {
+        out.push('`');
+    }
+    out.push_str(lang);
+    out.push('\n');
+    out.push_str(body);
+    if !body.ends_with('\n') {
+        out.push('\n');
+    }
+    for _ in 0..n {
+        out.push('`');
+    }
+    out.push('\n');
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_fence_is_three() {
+        assert_eq!(fence_len_for("plain text\nwithout backticks"), 3);
+    }
+
+    #[test]
+    fn fence_escalates_past_inner_run() {
+        assert_eq!(fence_len_for("contains ``` triple"), 4);
+        assert_eq!(fence_len_for("contains ```` quad"), 5);
+    }
+
+    #[test]
+    fn write_fence_uses_correct_length() {
+        let mut s = String::new();
+        write_fence(&mut s, "rpl", "let x = 1;\n");
+        assert_eq!(s, "```rpl\nlet x = 1;\n```\n");
+
+        let mut s = String::new();
+        write_fence(&mut s, "rpl", "look: ```\n");
+        assert_eq!(s, "````rpl\nlook: ```\n````\n");
+    }
+}

--- a/crates/rpl_doc/src/render.rs
+++ b/crates/rpl_doc/src/render.rs
@@ -21,6 +21,37 @@ pub(crate) fn fence_len_for(body: &str) -> usize {
     std::cmp::max(3, max_run + 1)
 }
 
+/// Wrap `value` in a backtick code span, escalating the fence length if
+/// `value` contains backticks. Returns a string like `` `value` `` or
+/// `` `` `value with `inner` backticks` `` `` with proper escalation.
+pub(crate) fn inline_code(value: &str) -> String {
+    // Count the longest run of backticks inside the value.
+    let mut max_run = 0usize;
+    let mut cur = 0usize;
+    for c in value.chars() {
+        if c == '`' {
+            cur += 1;
+            if cur > max_run {
+                max_run = cur;
+            }
+        } else {
+            cur = 0;
+        }
+    }
+    // Inline spans need at least 1 backtick (not the 3-tick floor for fences).
+    let n = max_run + 1;
+    let ticks: String = "`".repeat(n);
+    // Add a space whenever the fence is longer than 1 tick (CommonMark rule:
+    // avoids the content being mis-parsed as part of the delimiter), and also
+    // when the value starts or ends with a backtick.
+    let needs_pad = n > 1 || value.starts_with('`') || value.ends_with('`');
+    if needs_pad {
+        format!("{ticks} {value} {ticks}")
+    } else {
+        format!("{ticks}{value}{ticks}")
+    }
+}
+
 /// Helper: write a fenced code block to `out`, escalating the fence length
 /// as needed to safely embed `body`.
 pub(crate) fn write_fence(out: &mut String, lang: &str, body: &str) {
@@ -114,22 +145,22 @@ fn render_diag(out: &mut String, d: &DocDiag) {
         out.push_str("\n\n");
     }
     if let Some(s) = &d.primary {
-        out.push_str(&format!("- **Primary:** `{s}`\n"));
+        out.push_str(&format!("- **Primary:** {}\n", inline_code(s)));
     }
     if let Some(s) = &d.label {
-        out.push_str(&format!("- **Label:** `{s}`\n"));
+        out.push_str(&format!("- **Label:** {}\n", inline_code(s)));
     }
     if let Some(s) = &d.help {
-        out.push_str(&format!("- **Help:** `{s}`\n"));
+        out.push_str(&format!("- **Help:** {}\n", inline_code(s)));
     }
     if let Some(s) = &d.note {
-        out.push_str(&format!("- **Note:** `{s}`\n"));
+        out.push_str(&format!("- **Note:** {}\n", inline_code(s)));
     }
     if let Some(s) = &d.level {
-        out.push_str(&format!("- **Level:** `{s}`\n"));
+        out.push_str(&format!("- **Level:** {}\n", inline_code(s)));
     }
     if let Some(s) = &d.lint_name {
-        out.push_str(&format!("- **Lint name:** `{s}`\n"));
+        out.push_str(&format!("- **Lint name:** {}\n", inline_code(s)));
     }
     out.push_str("\n");
 }
@@ -157,6 +188,18 @@ mod tests {
     fn fence_escalates_past_inner_run() {
         assert_eq!(fence_len_for("contains ``` triple"), 4);
         assert_eq!(fence_len_for("contains ```` quad"), 5);
+    }
+
+    #[test]
+    fn inline_code_escalates_for_inner_backticks() {
+        assert_eq!(inline_code("plain"), "`plain`");
+        assert_eq!(inline_code("has `inner` backticks"), "`` has `inner` backticks ``");
+    }
+
+    #[test]
+    fn inline_code_pads_when_value_starts_or_ends_with_backtick() {
+        assert_eq!(inline_code("`x"), "`` `x ``");
+        assert_eq!(inline_code("x`"), "`` x` ``");
     }
 
     #[test]

--- a/crates/rpl_doc/src/render.rs
+++ b/crates/rpl_doc/src/render.rs
@@ -127,9 +127,7 @@ fn render_item(out: &mut String, item: &DocItem) {
         out.push_str("\n\n");
     }
     if let Some(diag) = &item.diag_attr {
-        out.push_str(&format!(
-            "**Diagnostic:** [`{diag}`](#diagnostic-{diag})\n\n",
-        ));
+        out.push_str(&format!("**Diagnostic:** [`{diag}`](#diagnostic-{diag})\n\n",));
     }
     out.push_str(&format!("**Signature:** `{}`\n\n", item.signature));
     out.push_str("<details><summary>Pattern body</summary>\n\n");
@@ -162,7 +160,7 @@ fn render_diag(out: &mut String, d: &DocDiag) {
     if let Some(s) = &d.lint_name {
         out.push_str(&format!("- **Lint name:** {}\n", inline_code(s)));
     }
-    out.push_str("\n");
+    out.push('\n');
 }
 
 fn render_example(out: &mut String, ex: &DocExample) {
@@ -172,7 +170,7 @@ fn render_example(out: &mut String, ex: &DocExample) {
         out.push_str("\n\n");
     }
     write_fence(out, "rust", &ex.source);
-    out.push_str("\n");
+    out.push('\n');
 }
 
 #[cfg(test)]
@@ -216,8 +214,9 @@ mod tests {
 
 #[cfg(test)]
 mod render_doc_file_tests {
-    use super::*;
     use std::path::PathBuf;
+
+    use super::*;
 
     fn empty_doc() -> DocFile {
         DocFile {
@@ -291,9 +290,9 @@ mod render_doc_file_tests {
         assert!(out.contains("<a id=\"diagnostic-p_diag\"></a>"));
         assert!(out.contains("### Diagnostic: `p_diag`"));
         assert!(out.contains("- **Primary:** `primary msg`"));
-        assert!(!out.contains("- **Label:**"));   // omitted
+        assert!(!out.contains("- **Label:**")); // omitted
         assert!(out.contains("- **Help:** `help msg`"));
-        assert!(!out.contains("- **Note:**"));   // omitted
+        assert!(!out.contains("- **Note:**")); // omitted
         assert!(out.contains("- **Level:** `deny`"));
         assert!(out.contains("- **Lint name:** `foo_lint`"));
     }

--- a/crates/rpl_doc/src/render.rs
+++ b/crates/rpl_doc/src/render.rs
@@ -129,7 +129,7 @@ fn render_item(out: &mut String, item: &DocItem) {
     if let Some(diag) = &item.diag_attr {
         out.push_str(&format!("**Diagnostic:** [`{diag}`](#diagnostic-{diag})\n\n",));
     }
-    out.push_str(&format!("**Signature:** `{}`\n\n", item.signature));
+    out.push_str(&format!("**Signature:** {}\n\n", inline_code(&item.signature)));
     out.push_str("<details><summary>Pattern body</summary>\n\n");
     write_fence(out, "rpl", &item.body_source);
     out.push_str("</details>\n\n");

--- a/crates/rpl_doc/src/render.rs
+++ b/crates/rpl_doc/src/render.rs
@@ -40,6 +40,110 @@ pub(crate) fn write_fence(out: &mut String, lang: &str, body: &str) {
     out.push('\n');
 }
 
+/// Render a `DocFile` to a Markdown `String`.
+pub(crate) fn render(doc: &DocFile) -> String {
+    let mut out = String::new();
+
+    // Title
+    out.push_str(&format!("# {}\n\n", doc.header_name));
+
+    // File-level prose
+    for run in &doc.file_doc {
+        out.push_str(run);
+        out.push_str("\n\n");
+    }
+
+    // Patterns
+    if !doc.patterns.is_empty() {
+        out.push_str("## Patterns\n\n");
+        for item in &doc.patterns {
+            render_item(&mut out, item);
+        }
+    }
+
+    // Utilities
+    if !doc.utilities.is_empty() {
+        out.push_str("## Utilities\n\n");
+        for item in &doc.utilities {
+            render_item(&mut out, item);
+        }
+    }
+
+    // Diagnostics
+    if !doc.diagnostics.is_empty() {
+        out.push_str("## Diagnostics\n\n");
+        for d in &doc.diagnostics {
+            render_diag(&mut out, d);
+        }
+    }
+
+    // Examples
+    if !doc.examples.is_empty() {
+        out.push_str("## Examples\n\n");
+        for ex in &doc.examples {
+            render_example(&mut out, ex);
+        }
+    }
+
+    out
+}
+
+fn render_item(out: &mut String, item: &DocItem) {
+    let mv = item.meta_vars.as_deref().unwrap_or("");
+    out.push_str(&format!("### `{}{mv}`\n\n", item.name));
+    for run in &item.doc {
+        out.push_str(run);
+        out.push_str("\n\n");
+    }
+    if let Some(diag) = &item.diag_attr {
+        out.push_str(&format!(
+            "**Diagnostic:** [`{diag}`](#diagnostic-{diag})\n\n",
+        ));
+    }
+    out.push_str(&format!("**Signature:** `{}`\n\n", item.signature));
+    out.push_str("<details><summary>Pattern body</summary>\n\n");
+    write_fence(out, "rpl", &item.body_source);
+    out.push_str("</details>\n\n");
+}
+
+fn render_diag(out: &mut String, d: &DocDiag) {
+    out.push_str(&format!("<a id=\"diagnostic-{}\"></a>\n", d.name));
+    out.push_str(&format!("### Diagnostic: `{}`\n\n", d.name));
+    for run in &d.doc {
+        out.push_str(run);
+        out.push_str("\n\n");
+    }
+    if let Some(s) = &d.primary {
+        out.push_str(&format!("- **Primary:** `{s}`\n"));
+    }
+    if let Some(s) = &d.label {
+        out.push_str(&format!("- **Label:** `{s}`\n"));
+    }
+    if let Some(s) = &d.help {
+        out.push_str(&format!("- **Help:** `{s}`\n"));
+    }
+    if let Some(s) = &d.note {
+        out.push_str(&format!("- **Note:** `{s}`\n"));
+    }
+    if let Some(s) = &d.level {
+        out.push_str(&format!("- **Level:** `{s}`\n"));
+    }
+    if let Some(s) = &d.lint_name {
+        out.push_str(&format!("- **Lint name:** `{s}`\n"));
+    }
+    out.push_str("\n");
+}
+
+fn render_example(out: &mut String, ex: &DocExample) {
+    out.push_str(&format!("### Example: `{}`\n\n", ex.filename));
+    for run in &ex.leading_doc {
+        out.push_str(run);
+        out.push_str("\n\n");
+    }
+    write_fence(out, "rust", &ex.source);
+    out.push_str("\n");
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -64,5 +168,119 @@ mod tests {
         let mut s = String::new();
         write_fence(&mut s, "rpl", "look: ```\n");
         assert_eq!(s, "````rpl\nlook: ```\n````\n");
+    }
+}
+
+#[cfg(test)]
+mod render_doc_file_tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn empty_doc() -> DocFile {
+        DocFile {
+            path: PathBuf::from("/x/Foo.rpl"),
+            header_name: "Foo".into(),
+            file_doc: vec![],
+            patterns: vec![],
+            utilities: vec![],
+            diagnostics: vec![],
+            examples: vec![],
+        }
+    }
+
+    #[test]
+    fn header_only_renders_just_title() {
+        let out = render(&empty_doc());
+        assert_eq!(out, "# Foo\n\n");
+    }
+
+    #[test]
+    fn file_doc_appears_after_title() {
+        let mut doc = empty_doc();
+        doc.file_doc = vec!["intro line 1\nintro line 2".into()];
+        let out = render(&doc);
+        assert!(out.starts_with("# Foo\n\nintro line 1\nintro line 2\n\n"));
+    }
+
+    #[test]
+    fn empty_sections_are_omitted() {
+        let out = render(&empty_doc());
+        assert!(!out.contains("## Patterns"));
+        assert!(!out.contains("## Utilities"));
+        assert!(!out.contains("## Diagnostics"));
+        assert!(!out.contains("## Examples"));
+    }
+
+    #[test]
+    fn pattern_section_emitted_when_nonempty() {
+        let mut doc = empty_doc();
+        doc.patterns.push(DocItem {
+            name: "p_foo".into(),
+            meta_vars: None,
+            doc: vec!["docs".into()],
+            diag_attr: Some("p_diag".into()),
+            signature: "fn _ (..) -> _".into(),
+            body_source: "let x = 1;".into(),
+        });
+        let out = render(&doc);
+        assert!(out.contains("## Patterns"));
+        assert!(out.contains("### `p_foo`"));
+        assert!(out.contains("docs"));
+        assert!(out.contains("[`p_diag`](#diagnostic-p_diag)"));
+        assert!(out.contains("**Signature:** `fn _ (..) -> _`"));
+        assert!(out.contains("```rpl\nlet x = 1;\n```"));
+    }
+
+    #[test]
+    fn diag_section_has_anchor_and_fields() {
+        let mut doc = empty_doc();
+        doc.diagnostics.push(DocDiag {
+            name: "p_diag".into(),
+            doc: vec![],
+            primary: Some("primary msg".into()),
+            label: None,
+            help: Some("help msg".into()),
+            note: None,
+            level: Some("deny".into()),
+            lint_name: Some("foo_lint".into()),
+        });
+        let out = render(&doc);
+        assert!(out.contains("<a id=\"diagnostic-p_diag\"></a>"));
+        assert!(out.contains("### Diagnostic: `p_diag`"));
+        assert!(out.contains("- **Primary:** `primary msg`"));
+        assert!(!out.contains("- **Label:**"));   // omitted
+        assert!(out.contains("- **Help:** `help msg`"));
+        assert!(!out.contains("- **Note:**"));   // omitted
+        assert!(out.contains("- **Level:** `deny`"));
+        assert!(out.contains("- **Lint name:** `foo_lint`"));
+    }
+
+    #[test]
+    fn example_with_leading_doc_renders_prose_before_fence() {
+        let mut doc = empty_doc();
+        doc.examples.push(DocExample {
+            filename: "basic.rs".into(),
+            leading_doc: vec!["intro".into()],
+            source: "fn main() {}".into(),
+        });
+        let out = render(&doc);
+        let i_intro = out.find("intro").unwrap();
+        let i_fence = out.find("```rust").unwrap();
+        assert!(i_intro < i_fence);
+    }
+
+    #[test]
+    fn pattern_with_meta_vars_renders_brackets() {
+        let mut doc = empty_doc();
+        doc.patterns.push(DocItem {
+            name: "p_foo".into(),
+            meta_vars: Some("[$T: type]".into()),
+            doc: vec![],
+            diag_attr: None,
+            signature: "fn _ (..) -> _".into(),
+            body_source: "let x = 1;".into(),
+        });
+        let out = render(&doc);
+        assert!(out.contains("### `p_foo[$T: type]`"));
     }
 }

--- a/crates/rpl_doc/tests/cli.rs
+++ b/crates/rpl_doc/tests/cli.rs
@@ -1,0 +1,135 @@
+//! End-to-end tests driving the `cargo-rpl doc` binary.
+
+#![feature(rustc_private)]
+
+use std::path::Path;
+use std::process::Command;
+
+fn cargo_rpl_bin() -> std::path::PathBuf {
+    // The `CARGO_BIN_EXE_cargo-rpl` env var is only set when the binary lives
+    // in the same package as the test. Since `cargo-rpl` is defined in the
+    // workspace root package while this test crate is `rpl_doc`, we locate
+    // the binary from the workspace `target/` tree at runtime.
+    //
+    // Strategy (in priority order):
+    // 1. `CARGO_BIN_EXE_cargo-rpl` — set when Cargo does supply it (e.g. if
+    //    the project is restructured in the future).
+    // 2. Walk up from `CARGO_MANIFEST_DIR` to find the workspace root, then
+    //    locate `target/{profile}/cargo-rpl`.
+    if let Ok(p) = std::env::var("CARGO_BIN_EXE_cargo-rpl") {
+        return std::path::PathBuf::from(p);
+    }
+
+    // CARGO_MANIFEST_DIR points to crates/rpl_doc; go up two levels to
+    // reach the workspace root.
+    let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let workspace_root = manifest_dir
+        .parent() // crates/
+        .and_then(|p| p.parent()) // workspace root
+        .expect("could not locate workspace root from CARGO_MANIFEST_DIR");
+
+    // Prefer the same profile the test was built with.  We approximate
+    // this by checking PROFILE env var (set by some CI setups) or falling
+    // back to "debug".
+    let profile = std::env::var("CARGO_PROFILE").unwrap_or_else(|_| "debug".to_string());
+    let mut bin = workspace_root.join("target").join(&profile).join("cargo-rpl");
+
+    if cfg!(windows) {
+        bin.set_extension("exe");
+    }
+
+    // If the profiled path doesn't exist, fall back to debug.
+    if !bin.exists() && profile != "debug" {
+        let mut fallback = workspace_root.join("target").join("debug").join("cargo-rpl");
+        if cfg!(windows) {
+            fallback.set_extension("exe");
+        }
+        if fallback.exists() {
+            return fallback;
+        }
+    }
+
+    bin
+}
+
+#[test]
+fn single_file_mode_writes_md_next_to_rpl() {
+    let td = tempfile::TempDir::new().unwrap();
+    let rpl = td.path().join("Foo.rpl");
+    std::fs::write(&rpl, "pattern Foo\n").unwrap();
+
+    let status = Command::new(cargo_rpl_bin())
+        .arg("rpl")
+        .arg("doc")
+        .arg(&rpl)
+        .arg("--quiet")
+        .status()
+        .expect("spawn");
+    assert!(status.success());
+
+    let out = td.path().join("Foo.md");
+    let md = std::fs::read_to_string(&out).expect("expected output file");
+    assert!(md.starts_with("# Foo"));
+}
+
+#[test]
+fn directory_mode_walks_recursively() {
+    let td = tempfile::TempDir::new().unwrap();
+    std::fs::write(td.path().join("A.rpl"), "pattern A\n").unwrap();
+    let sub = td.path().join("nested");
+    std::fs::create_dir(&sub).unwrap();
+    std::fs::write(sub.join("B.rpl"), "pattern B\n").unwrap();
+
+    let status = Command::new(cargo_rpl_bin())
+        .arg("rpl")
+        .arg("doc")
+        .arg(td.path())
+        .arg("--quiet")
+        .status()
+        .expect("spawn");
+    assert!(status.success());
+
+    assert!(td.path().join("A.md").exists());
+    assert!(sub.join("B.md").exists());
+}
+
+#[test]
+fn parse_error_exits_nonzero() {
+    let td = tempfile::TempDir::new().unwrap();
+    let rpl = td.path().join("Bad.rpl");
+    std::fs::write(&rpl, "garbage not a pattern\n").unwrap();
+
+    let status = Command::new(cargo_rpl_bin())
+        .arg("rpl")
+        .arg("doc")
+        .arg(&rpl)
+        .status()
+        .expect("spawn");
+    assert!(!status.success());
+}
+
+#[test]
+fn output_flag_mirrors_input_tree() {
+    let td_in = tempfile::TempDir::new().unwrap();
+    let td_out = tempfile::TempDir::new().unwrap();
+    std::fs::write(td_in.path().join("A.rpl"), "pattern A\n").unwrap();
+    let sub = td_in.path().join("nested");
+    std::fs::create_dir(&sub).unwrap();
+    std::fs::write(sub.join("B.rpl"), "pattern B\n").unwrap();
+
+    let status = Command::new(cargo_rpl_bin())
+        .arg("rpl")
+        .arg("doc")
+        .arg(td_in.path())
+        .arg("--output")
+        .arg(td_out.path())
+        .arg("--quiet")
+        .status()
+        .expect("spawn");
+    assert!(status.success());
+
+    assert!(td_out.path().join("A.md").exists());
+    assert!(td_out.path().join("nested/B.md").exists());
+    // Input tree was not modified.
+    assert!(!td_in.path().join("A.md").exists());
+}

--- a/crates/rpl_doc/tests/cli.rs
+++ b/crates/rpl_doc/tests/cli.rs
@@ -12,10 +12,10 @@ fn cargo_rpl_bin() -> std::path::PathBuf {
     // the binary from the workspace `target/` tree at runtime.
     //
     // Strategy (in priority order):
-    // 1. `CARGO_BIN_EXE_cargo-rpl` — set when Cargo does supply it (e.g. if
-    //    the project is restructured in the future).
-    // 2. Walk up from `CARGO_MANIFEST_DIR` to find the workspace root, then
-    //    locate `target/{profile}/cargo-rpl`.
+    // 1. `CARGO_BIN_EXE_cargo-rpl` — set when Cargo does supply it (e.g. if the project is restructured
+    //    in the future).
+    // 2. Walk up from `CARGO_MANIFEST_DIR` to find the workspace root, then locate
+    //    `target/{profile}/cargo-rpl`.
     if let Ok(p) = std::env::var("CARGO_BIN_EXE_cargo-rpl") {
         return std::path::PathBuf::from(p);
     }

--- a/crates/rpl_doc/tests/cli.rs
+++ b/crates/rpl_doc/tests/cli.rs
@@ -6,50 +6,23 @@ use std::path::Path;
 use std::process::Command;
 
 fn cargo_rpl_bin() -> std::path::PathBuf {
-    // The `CARGO_BIN_EXE_cargo-rpl` env var is only set when the binary lives
-    // in the same package as the test. Since `cargo-rpl` is defined in the
-    // workspace root package while this test crate is `rpl_doc`, we locate
-    // the binary from the workspace `target/` tree at runtime.
-    //
-    // Strategy (in priority order):
-    // 1. `CARGO_BIN_EXE_cargo-rpl` — set when Cargo does supply it (e.g. if the project is restructured
-    //    in the future).
-    // 2. Walk up from `CARGO_MANIFEST_DIR` to find the workspace root, then locate
-    //    `target/{profile}/cargo-rpl`.
-    if let Ok(p) = std::env::var("CARGO_BIN_EXE_cargo-rpl") {
-        return std::path::PathBuf::from(p);
+    // If Cargo set CARGO_BIN_EXE_cargo-rpl (it does for tests living in the
+    // same package as the binary), use it directly.
+    if let Ok(path) = std::env::var("CARGO_BIN_EXE_cargo-rpl") {
+        return std::path::PathBuf::from(path);
     }
 
-    // CARGO_MANIFEST_DIR points to crates/rpl_doc; go up two levels to
-    // reach the workspace root.
-    let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
-    let workspace_root = manifest_dir
-        .parent() // crates/
-        .and_then(|p| p.parent()) // workspace root
-        .expect("could not locate workspace root from CARGO_MANIFEST_DIR");
-
-    // Prefer the same profile the test was built with.  We approximate
-    // this by checking PROFILE env var (set by some CI setups) or falling
-    // back to "debug".
-    let profile = std::env::var("CARGO_PROFILE").unwrap_or_else(|_| "debug".to_string());
-    let mut bin = workspace_root.join("target").join(&profile).join("cargo-rpl");
-
-    if cfg!(windows) {
-        bin.set_extension("exe");
-    }
-
-    // If the profiled path doesn't exist, fall back to debug.
-    if !bin.exists() && profile != "debug" {
-        let mut fallback = workspace_root.join("target").join("debug").join("cargo-rpl");
-        if cfg!(windows) {
-            fallback.set_extension("exe");
-        }
-        if fallback.exists() {
-            return fallback;
-        }
-    }
-
-    bin
+    // Otherwise: this integration-test binary lives at
+    //   target/<profile>/deps/cli-<hash>(.exe)
+    // The cargo-rpl binary is a sibling of `deps/`:
+    //   target/<profile>/cargo-rpl(.exe)
+    let test_exe = std::env::current_exe().expect("current_exe");
+    let target_profile = test_exe
+        .parent() // .../target/<profile>/deps
+        .and_then(Path::parent) // .../target/<profile>
+        .expect("test binary should live under target/<profile>/deps/");
+    let exe_name = if cfg!(windows) { "cargo-rpl.exe" } else { "cargo-rpl" };
+    target_profile.join(exe_name)
 }
 
 #[test]
@@ -132,4 +105,20 @@ fn output_flag_mirrors_input_tree() {
     assert!(td_out.path().join("nested/B.md").exists());
     // Input tree was not modified.
     assert!(!td_in.path().join("A.md").exists());
+}
+
+#[test]
+fn unknown_flag_exits_nonzero() {
+    let td = tempfile::TempDir::new().unwrap();
+    let rpl = td.path().join("Foo.rpl");
+    std::fs::write(&rpl, "pattern Foo\n").unwrap();
+
+    let status = Command::new(cargo_rpl_bin())
+        .arg("rpl")
+        .arg("doc")
+        .arg(&rpl)
+        .arg("--verbose") // unknown flag
+        .status()
+        .expect("spawn");
+    assert!(!status.success(), "should reject --verbose");
 }

--- a/crates/rpl_doc/tests/corpus_sweep.rs
+++ b/crates/rpl_doc/tests/corpus_sweep.rs
@@ -1,0 +1,60 @@
+//! Backward-compatibility gate: every .rpl file under docs/patterns-pest/
+//! must parse successfully under the rpl_parser grammar.
+//!
+//! Today (pre-grammar-change) this test should pass against the unchanged
+//! grammar. After the grammar change in Task B3, it must STILL pass —
+//! that is its purpose: catch any regression in pattern-file acceptance.
+
+#![feature(rustc_private)]
+
+use std::path::{Path, PathBuf};
+
+fn workspace_root() -> PathBuf {
+    // CARGO_MANIFEST_DIR points at crates/rpl_doc/; go up two levels.
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .to_path_buf()
+}
+
+fn all_rpl_files() -> Vec<PathBuf> {
+    let patterns_dir = workspace_root().join("docs/patterns-pest");
+    walkdir::WalkDir::new(&patterns_dir)
+        .into_iter()
+        .filter_map(Result::ok)
+        .filter(|e| e.file_type().is_file())
+        .filter(|e| e.path().extension().and_then(|s| s.to_str()) == Some("rpl"))
+        .map(|e| e.into_path())
+        .collect()
+}
+
+#[test]
+fn existing_patterns_still_parse_after_grammar_change() {
+    let files = all_rpl_files();
+    assert!(!files.is_empty(), "expected at least one .rpl under docs/patterns-pest/");
+
+    let mut failures = Vec::new();
+    for path in &files {
+        let source = match std::fs::read_to_string(path) {
+            Ok(s) => s,
+            Err(e) => {
+                failures.push(format!("read {}: {e}", path.display()));
+                continue;
+            }
+        };
+        if let Err(e) = rpl_doc::parse_only(path, &source) {
+            failures.push(format!("parse {}: {e}", path.display()));
+        }
+    }
+
+    if !failures.is_empty() {
+        panic!(
+            "{} of {} pattern files failed to parse:\n{}",
+            failures.len(),
+            files.len(),
+            failures.join("\n")
+        );
+    }
+}

--- a/crates/rpl_doc/tests/corpus_sweep.rs
+++ b/crates/rpl_doc/tests/corpus_sweep.rs
@@ -33,7 +33,10 @@ fn all_rpl_files() -> Vec<PathBuf> {
 #[test]
 fn existing_patterns_still_parse_after_grammar_change() {
     let files = all_rpl_files();
-    assert!(!files.is_empty(), "expected at least one .rpl under docs/patterns-pest/");
+    assert!(
+        !files.is_empty(),
+        "expected at least one .rpl under docs/patterns-pest/"
+    );
 
     let mut failures = Vec::new();
     for path in &files {
@@ -42,7 +45,7 @@ fn existing_patterns_still_parse_after_grammar_change() {
             Err(e) => {
                 failures.push(format!("read {}: {e}", path.display()));
                 continue;
-            }
+            },
         };
         if let Err(e) = rpl_doc::parse_only(path, &source) {
             failures.push(format!("parse {}: {e}", path.display()));

--- a/crates/rpl_doc/tests/fixtures/body_with_backticks.expected.md
+++ b/crates/rpl_doc/tests/fixtures/body_with_backticks.expected.md
@@ -1,0 +1,16 @@
+# BodyWithBackticks
+
+## Patterns
+
+### `p_foo`
+
+**Signature:** `fn _ (..) -> _`
+
+<details><summary>Pattern body</summary>
+
+````rpl
+// contains literal ``` triple backtick in a comment
+_ = const 0_usize;
+````
+</details>
+

--- a/crates/rpl_doc/tests/fixtures/body_with_backticks.rpl
+++ b/crates/rpl_doc/tests/fixtures/body_with_backticks.rpl
@@ -1,0 +1,8 @@
+pattern BodyWithBackticks
+
+patt {
+    p_foo = fn _ (..) -> _ {
+        // contains literal ``` triple backtick in a comment
+        _ = const 0_usize;
+    }
+}

--- a/crates/rpl_doc/tests/fixtures/diag_with_doc.expected.md
+++ b/crates/rpl_doc/tests/fixtures/diag_with_doc.expected.md
@@ -1,0 +1,13 @@
+# DiagWithDoc
+
+## Diagnostics
+
+<a id="diagnostic-p_diag"></a>
+### Diagnostic: `p_diag`
+
+Description of the diagnostic.
+
+- **Primary:** `primary message`
+- **Level:** `deny`
+- **Lint name:** `my_lint`
+

--- a/crates/rpl_doc/tests/fixtures/diag_with_doc.rpl
+++ b/crates/rpl_doc/tests/fixtures/diag_with_doc.rpl
@@ -1,0 +1,10 @@
+pattern DiagWithDoc
+
+diag {
+    /// Description of the diagnostic.
+    p_diag = {
+        primary(span) = "primary message",
+        level = "deny",
+        name = "my_lint",
+    }
+}

--- a/crates/rpl_doc/tests/fixtures/minimal.expected.md
+++ b/crates/rpl_doc/tests/fixtures/minimal.expected.md
@@ -1,0 +1,2 @@
+# Minimal
+

--- a/crates/rpl_doc/tests/fixtures/minimal.rpl
+++ b/crates/rpl_doc/tests/fixtures/minimal.rpl
@@ -1,0 +1,1 @@
+pattern Minimal

--- a/crates/rpl_doc/tests/fixtures/multi_block.expected.md
+++ b/crates/rpl_doc/tests/fixtures/multi_block.expected.md
@@ -1,0 +1,37 @@
+# MultiBlock
+
+## Patterns
+
+### `p_a`
+
+**Signature:** `fn _ (..) -> _`
+
+<details><summary>Pattern body</summary>
+
+```rpl
+_ = const 0_usize;
+```
+</details>
+
+## Utilities
+
+### `u_b`
+
+**Signature:** `fn _ (..) -> _`
+
+<details><summary>Pattern body</summary>
+
+```rpl
+_ = const 0_usize;
+```
+</details>
+
+## Diagnostics
+
+<a id="diagnostic-p_a"></a>
+### Diagnostic: `p_a`
+
+- **Primary:** `msg`
+- **Level:** `deny`
+- **Lint name:** `lint`
+

--- a/crates/rpl_doc/tests/fixtures/multi_block.rpl
+++ b/crates/rpl_doc/tests/fixtures/multi_block.rpl
@@ -1,0 +1,21 @@
+pattern MultiBlock
+
+patt {
+    p_a = fn _ (..) -> _ {
+        _ = const 0_usize;
+    }
+}
+
+util {
+    u_b = fn _ (..) -> _ {
+        _ = const 0_usize;
+    }
+}
+
+diag {
+    p_a = {
+        primary(span) = "msg",
+        level = "deny",
+        name = "lint",
+    }
+}

--- a/crates/rpl_doc/tests/fixtures/patt_with_doc.expected.md
+++ b/crates/rpl_doc/tests/fixtures/patt_with_doc.expected.md
@@ -1,0 +1,19 @@
+# PattWithDoc
+
+Top-level prose for this pattern file.
+
+## Patterns
+
+### `p_foo`
+
+Item-level documentation for `p_foo`.
+
+**Signature:** `fn _ (..) -> _`
+
+<details><summary>Pattern body</summary>
+
+```rpl
+_ = const 0_usize;
+```
+</details>
+

--- a/crates/rpl_doc/tests/fixtures/patt_with_doc.rpl
+++ b/crates/rpl_doc/tests/fixtures/patt_with_doc.rpl
@@ -1,0 +1,10 @@
+//! Top-level prose for this pattern file.
+
+pattern PattWithDoc
+
+patt {
+    /// Item-level documentation for `p_foo`.
+    p_foo = fn _ (..) -> _ {
+        _ = const 0_usize;
+    }
+}

--- a/crates/rpl_doc/tests/fixtures/with_examples.expected.md
+++ b/crates/rpl_doc/tests/fixtures/with_examples.expected.md
@@ -1,0 +1,27 @@
+# WithExamples
+
+## Patterns
+
+### `p_foo`
+
+**Signature:** `fn _ (..) -> _`
+
+<details><summary>Pattern body</summary>
+
+```rpl
+_ = const 0_usize;
+```
+</details>
+
+## Examples
+
+### Example: `positive.rs`
+
+This file demonstrates the triggering case.
+
+```rust
+fn main() {
+    let _ = 0usize;
+}
+```
+

--- a/crates/rpl_doc/tests/fixtures/with_examples.rpl
+++ b/crates/rpl_doc/tests/fixtures/with_examples.rpl
@@ -1,0 +1,7 @@
+pattern WithExamples
+
+patt {
+    p_foo = fn _ (..) -> _ {
+        _ = const 0_usize;
+    }
+}

--- a/crates/rpl_doc/tests/fixtures/with_examples/positive.rs
+++ b/crates/rpl_doc/tests/fixtures/with_examples/positive.rs
@@ -1,0 +1,5 @@
+//! This file demonstrates the triggering case.
+
+fn main() {
+    let _ = 0usize;
+}

--- a/crates/rpl_doc/tests/integration.rs
+++ b/crates/rpl_doc/tests/integration.rs
@@ -2,8 +2,9 @@
 
 #![feature(rustc_private)]
 
-use pretty_assertions::assert_eq;
 use std::path::Path;
+
+use pretty_assertions::assert_eq;
 
 fn fixture_dir() -> std::path::PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures")
@@ -14,14 +15,32 @@ fn assert_fixture(name: &str) {
     let expected_path = fixture_dir().join(format!("{name}.expected.md"));
     let expected = std::fs::read_to_string(&expected_path)
         .unwrap_or_else(|_| panic!("missing fixture {}", expected_path.display()));
-    let actual = rpl_doc::render_markdown(&rpl)
-        .unwrap_or_else(|e| panic!("render_markdown({}) failed: {e}", rpl.display()));
+    let actual =
+        rpl_doc::render_markdown(&rpl).unwrap_or_else(|e| panic!("render_markdown({}) failed: {e}", rpl.display()));
     assert_eq!(actual, expected, "fixture: {name}");
 }
 
-#[test] fn minimal() { assert_fixture("minimal"); }
-#[test] fn patt_with_doc() { assert_fixture("patt_with_doc"); }
-#[test] fn diag_with_doc() { assert_fixture("diag_with_doc"); }
-#[test] fn with_examples() { assert_fixture("with_examples"); }
-#[test] fn body_with_backticks() { assert_fixture("body_with_backticks"); }
-#[test] fn multi_block() { assert_fixture("multi_block"); }
+#[test]
+fn minimal() {
+    assert_fixture("minimal");
+}
+#[test]
+fn patt_with_doc() {
+    assert_fixture("patt_with_doc");
+}
+#[test]
+fn diag_with_doc() {
+    assert_fixture("diag_with_doc");
+}
+#[test]
+fn with_examples() {
+    assert_fixture("with_examples");
+}
+#[test]
+fn body_with_backticks() {
+    assert_fixture("body_with_backticks");
+}
+#[test]
+fn multi_block() {
+    assert_fixture("multi_block");
+}

--- a/crates/rpl_doc/tests/integration.rs
+++ b/crates/rpl_doc/tests/integration.rs
@@ -17,6 +17,11 @@ fn assert_fixture(name: &str) {
         .unwrap_or_else(|_| panic!("missing fixture {}", expected_path.display()));
     let actual =
         rpl_doc::render_markdown(&rpl).unwrap_or_else(|e| panic!("render_markdown({}) failed: {e}", rpl.display()));
+    // Normalize CRLF→LF so the test isn't sensitive to how the fixture file
+    // was checked out (Windows git defaults to autocrlf on some configs).
+    // The renderer itself always emits LF; we only normalize the expected
+    // side here.
+    let expected = expected.replace("\r\n", "\n");
     assert_eq!(actual, expected, "fixture: {name}");
 }
 

--- a/crates/rpl_doc/tests/integration.rs
+++ b/crates/rpl_doc/tests/integration.rs
@@ -1,0 +1,25 @@
+//! Round-trip integration tests: parse + extract + render for paired fixtures.
+
+#![feature(rustc_private)]
+
+use pretty_assertions::assert_eq;
+use std::path::Path;
+
+fn fixture_dir() -> std::path::PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures")
+}
+
+fn assert_fixture(name: &str) {
+    let rpl = fixture_dir().join(format!("{name}.rpl"));
+    let expected_path = fixture_dir().join(format!("{name}.expected.md"));
+    let expected = std::fs::read_to_string(&expected_path)
+        .unwrap_or_else(|_| panic!("missing fixture {}", expected_path.display()));
+    let actual = rpl_doc::render_markdown(&rpl)
+        .unwrap_or_else(|e| panic!("render_markdown({}) failed: {e}", rpl.display()));
+    assert_eq!(actual, expected, "fixture: {name}");
+}
+
+#[test] fn minimal() { assert_fixture("minimal"); }
+#[test] fn patt_with_doc() { assert_fixture("patt_with_doc"); }
+#[test] fn diag_with_doc() { assert_fixture("diag_with_doc"); }
+#[test] fn with_examples() { assert_fixture("with_examples"); }

--- a/crates/rpl_doc/tests/integration.rs
+++ b/crates/rpl_doc/tests/integration.rs
@@ -23,3 +23,5 @@ fn assert_fixture(name: &str) {
 #[test] fn patt_with_doc() { assert_fixture("patt_with_doc"); }
 #[test] fn diag_with_doc() { assert_fixture("diag_with_doc"); }
 #[test] fn with_examples() { assert_fixture("with_examples"); }
+#[test] fn body_with_backticks() { assert_fixture("body_with_backticks"); }
+#[test] fn multi_block() { assert_fixture("multi_block"); }

--- a/crates/rpl_meta/src/check.rs
+++ b/crates/rpl_meta/src/check.rs
@@ -52,7 +52,7 @@ impl<'i> CheckCtxt<'i> {
     }
 
     pub fn check_pat_item(&mut self, mctx: &MetaContext<'i>, pat_item: &'i pairs::RPLPatternItem<'i>) {
-        let (_, _, meta_decl_list, _, rust_item_or_patt_operation) = pat_item.get_matched();
+        let (_, _, _, meta_decl_list, _, rust_item_or_patt_operation) = pat_item.get_matched();
         if let Some(meta_decl_list) = meta_decl_list {
             self.check_meta_decl_list(mctx, meta_decl_list);
         }

--- a/crates/rpl_meta/src/meta.rs
+++ b/crates/rpl_meta/src/meta.rs
@@ -65,7 +65,7 @@ impl<'mcx> SymbolTables<'mcx> {
 
     fn collect_rpl_pattern_name(main: &pairs::main<'mcx>) -> &'mcx str {
         let rpl_pattern = main.get_matched().1;
-        let rpl_header = rpl_pattern.get_matched().0;
+        let rpl_header = rpl_pattern.get_matched().1;
         let name = rpl_header.get_matched().1.span.as_str();
         name
     }
@@ -110,7 +110,7 @@ pub fn collect_blocks<'mcx, 'i>(
     let mut patts = Vec::new();
     let mut diags = Vec::new();
 
-    let blocks = main.get_matched().1.get_matched().1;
+    let blocks = main.get_matched().1.get_matched().2;
     let blocks = blocks.iter_matched();
 
     for block in blocks {

--- a/crates/rpl_meta/src/symbol_table/diag.rs
+++ b/crates/rpl_meta/src/symbol_table/diag.rs
@@ -39,7 +39,7 @@ impl<'i> DiagSymbolTable<'i> {
     ) -> FlatMap<&'i str, Self> {
         let mut diag_symbols = FlatMap::default();
         for diag in diags {
-            let name = diag.get_matched().0;
+            let name = diag.get_matched().1;
             let symbol_table = Self::collect_diag_symbol_table(mctx, diag, errors);
             _ = diag_symbols
                 .try_insert(name.span.as_str(), symbol_table)
@@ -61,7 +61,7 @@ impl<'i> DiagSymbolTable<'i> {
         errors: &mut Vec<RPLMetaError<'i>>,
     ) -> Self {
         let mut diag_symbol_table = DiagSymbolTable::default();
-        let (_, _, _, items, messages, _) = diag.get_matched();
+        let (_, _, _, _, items, messages, _) = diag.get_matched();
 
         diag_symbol_table.get_lint(items, mctx, errors);
 

--- a/crates/rpl_parser/src/grammar/RPL.pest
+++ b/crates/rpl_parser/src/grammar/RPL.pest
@@ -171,8 +171,24 @@ Keywords = @{
 }
 
 // Space and Comment
-COMMENT    = _{ "//" ~ (!(NEWLINE) ~ ANY)* | "/*" ~ (!"*/" ~ ANY)* ~ "*/" }
-WHITESPACE = _{ " " | "\t" | "\r" | "\n" }
+//
+// Doc comments are non-silent: they propagate into the AST at the three
+// designated attachment points (RPLPattern, RPLPatternItem, diagBlockItem)
+// and are otherwise rejected by the grammar.
+DocComment      = ${ OuterDocComment | InnerDocComment }
+OuterDocComment = ${ "///" ~ !"/" ~ DocCommentText }
+InnerDocComment = ${ "//!"        ~ DocCommentText }
+DocCommentText  = @{ (!NEWLINE ~ ANY)* }
+
+// Line and block comments are silently skipped. The negative lookaheads on
+// the line variant prevent us from re-consuming `///` / `//!` / `////` —
+// the `///` and `//!` cases are doc comments; `////` (four-or-more slashes)
+// is a decorative section divider, per Rust convention.
+LineCommentNonDoc = _{ "//" ~ !("/" | "!") ~ (!NEWLINE ~ ANY)*
+                     | "////" ~ (!NEWLINE ~ ANY)* }
+BlockComment      = _{ "/*" ~ (!"*/" ~ ANY)* ~ "*/" }
+COMMENT           = _{ LineCommentNonDoc | BlockComment }
+WHITESPACE        = _{ " " | "\t" | "\r" | "\n" }
 
 // Symbols
 LeftBrace    = @{ "{" }
@@ -923,7 +939,7 @@ Attr = {
 
 // patt block Item
 RPLPatternItem = {
-    Attr* ~ Identifier ~ MetaVariableDeclList? ~ Assign ~ RustItemsOrPatternOperation
+    OuterDocComment* ~ Attr* ~ Identifier ~ MetaVariableDeclList? ~ Assign ~ RustItemsOrPatternOperation
 }
 
 MetaVariableWithDiagMessage = {
@@ -968,7 +984,7 @@ diagItems = {
 
 // diag block Item
 diagBlockItem = {
-    Identifier ~ Assign ~ LeftBrace ~ diagItems ~ MetaVariableWithDiagMessageSeparatedByComma? ~ RightBrace
+    OuterDocComment* ~ Identifier ~ Assign ~ LeftBrace ~ diagItems ~ MetaVariableWithDiagMessageSeparatedByComma? ~ RightBrace
 }
 
 // RPL Blocks
@@ -987,7 +1003,7 @@ Block     = _{ pattBlock | utilBlock | diagBlock }
 RPLHeader = { kw_pattern ~ Identifier }
 
 // RPL Pattern
-RPLPattern = { RPLHeader ~ Block* }
+RPLPattern = { InnerDocComment* ~ RPLHeader ~ Block* }
 
 // RPL File entry
 main = { SOI ~ RPLPattern ~ EOI }

--- a/crates/rpl_parser/src/parser.rs
+++ b/crates/rpl_parser/src/parser.rs
@@ -94,6 +94,12 @@ pub enum Rule {
     r#kw_bool,
     r#kw_str,
     r#Keywords,
+    r#DocComment,
+    r#OuterDocComment,
+    r#InnerDocComment,
+    r#DocCommentText,
+    r#LineCommentNonDoc,
+    r#BlockComment,
     r#COMMENT,
     r#WHITESPACE,
     r#LeftBrace,
@@ -916,299 +922,299 @@ mod constant_wrappers {
     impl ::pest_typed::StringWrapper for r#w_86 {
         const CONTENT: &'static ::core::primitive::str = "str";
     }
-    #[doc = "A wrapper for `\"//\"`."]
+    #[doc = "A wrapper for `\"///\"`."]
     #[allow(non_camel_case_types)]
     #[derive(Clone, Hash, PartialEq, Eq)]
     pub struct r#w_87;
     impl ::pest_typed::StringWrapper for r#w_87 {
-        const CONTENT: &'static ::core::primitive::str = "//";
+        const CONTENT: &'static ::core::primitive::str = "///";
     }
-    #[doc = "A wrapper for `\"/*\"`."]
+    #[doc = "A wrapper for `\"/\"`."]
     #[allow(non_camel_case_types)]
     #[derive(Clone, Hash, PartialEq, Eq)]
     pub struct r#w_88;
     impl ::pest_typed::StringWrapper for r#w_88 {
+        const CONTENT: &'static ::core::primitive::str = "/";
+    }
+    #[doc = "A wrapper for `\"//!\"`."]
+    #[allow(non_camel_case_types)]
+    #[derive(Clone, Hash, PartialEq, Eq)]
+    pub struct r#w_89;
+    impl ::pest_typed::StringWrapper for r#w_89 {
+        const CONTENT: &'static ::core::primitive::str = "//!";
+    }
+    #[doc = "A wrapper for `\"//\"`."]
+    #[allow(non_camel_case_types)]
+    #[derive(Clone, Hash, PartialEq, Eq)]
+    pub struct r#w_90;
+    impl ::pest_typed::StringWrapper for r#w_90 {
+        const CONTENT: &'static ::core::primitive::str = "//";
+    }
+    #[doc = "A wrapper for `\"/\"`."]
+    #[allow(non_camel_case_types)]
+    #[derive(Clone, Hash, PartialEq, Eq)]
+    pub struct r#w_91;
+    impl ::pest_typed::StringWrapper for r#w_91 {
+        const CONTENT: &'static ::core::primitive::str = "/";
+    }
+    #[doc = "A wrapper for `\"!\"`."]
+    #[allow(non_camel_case_types)]
+    #[derive(Clone, Hash, PartialEq, Eq)]
+    pub struct r#w_92;
+    impl ::pest_typed::StringWrapper for r#w_92 {
+        const CONTENT: &'static ::core::primitive::str = "!";
+    }
+    #[doc = "A wrapper for `\"////\"`."]
+    #[allow(non_camel_case_types)]
+    #[derive(Clone, Hash, PartialEq, Eq)]
+    pub struct r#w_93;
+    impl ::pest_typed::StringWrapper for r#w_93 {
+        const CONTENT: &'static ::core::primitive::str = "////";
+    }
+    #[doc = "A wrapper for `\"/*\"`."]
+    #[allow(non_camel_case_types)]
+    #[derive(Clone, Hash, PartialEq, Eq)]
+    pub struct r#w_94;
+    impl ::pest_typed::StringWrapper for r#w_94 {
         const CONTENT: &'static ::core::primitive::str = "/*";
     }
     #[doc = "A wrapper for `\"*/\"`."]
     #[allow(non_camel_case_types)]
     #[derive(Clone, Hash, PartialEq, Eq)]
-    pub struct r#w_89;
-    impl ::pest_typed::StringWrapper for r#w_89 {
+    pub struct r#w_95;
+    impl ::pest_typed::StringWrapper for r#w_95 {
         const CONTENT: &'static ::core::primitive::str = "*/";
     }
     #[doc = "A wrapper for `\"*/\"`."]
     #[allow(non_camel_case_types)]
     #[derive(Clone, Hash, PartialEq, Eq)]
-    pub struct r#w_90;
-    impl ::pest_typed::StringWrapper for r#w_90 {
+    pub struct r#w_96;
+    impl ::pest_typed::StringWrapper for r#w_96 {
         const CONTENT: &'static ::core::primitive::str = "*/";
     }
     #[doc = "A wrapper for `\" \"`."]
     #[allow(non_camel_case_types)]
     #[derive(Clone, Hash, PartialEq, Eq)]
-    pub struct r#w_91;
-    impl ::pest_typed::StringWrapper for r#w_91 {
+    pub struct r#w_97;
+    impl ::pest_typed::StringWrapper for r#w_97 {
         const CONTENT: &'static ::core::primitive::str = " ";
     }
     #[doc = "A wrapper for `\"\\t\"`."]
     #[allow(non_camel_case_types)]
     #[derive(Clone, Hash, PartialEq, Eq)]
-    pub struct r#w_92;
-    impl ::pest_typed::StringWrapper for r#w_92 {
+    pub struct r#w_98;
+    impl ::pest_typed::StringWrapper for r#w_98 {
         const CONTENT: &'static ::core::primitive::str = "\t";
     }
     #[doc = "A wrapper for `\"\\r\"`."]
     #[allow(non_camel_case_types)]
     #[derive(Clone, Hash, PartialEq, Eq)]
-    pub struct r#w_93;
-    impl ::pest_typed::StringWrapper for r#w_93 {
+    pub struct r#w_99;
+    impl ::pest_typed::StringWrapper for r#w_99 {
         const CONTENT: &'static ::core::primitive::str = "\r";
     }
     #[doc = "A wrapper for `\"\\n\"`."]
     #[allow(non_camel_case_types)]
     #[derive(Clone, Hash, PartialEq, Eq)]
-    pub struct r#w_94;
-    impl ::pest_typed::StringWrapper for r#w_94 {
+    pub struct r#w_100;
+    impl ::pest_typed::StringWrapper for r#w_100 {
         const CONTENT: &'static ::core::primitive::str = "\n";
     }
     #[doc = "A wrapper for `\"{\"`."]
     #[allow(non_camel_case_types)]
     #[derive(Clone, Hash, PartialEq, Eq)]
-    pub struct r#w_95;
-    impl ::pest_typed::StringWrapper for r#w_95 {
+    pub struct r#w_101;
+    impl ::pest_typed::StringWrapper for r#w_101 {
         const CONTENT: &'static ::core::primitive::str = "{";
     }
     #[doc = "A wrapper for `\"}\"`."]
     #[allow(non_camel_case_types)]
     #[derive(Clone, Hash, PartialEq, Eq)]
-    pub struct r#w_96;
-    impl ::pest_typed::StringWrapper for r#w_96 {
+    pub struct r#w_102;
+    impl ::pest_typed::StringWrapper for r#w_102 {
         const CONTENT: &'static ::core::primitive::str = "}";
     }
     #[doc = "A wrapper for `\"[\"`."]
     #[allow(non_camel_case_types)]
     #[derive(Clone, Hash, PartialEq, Eq)]
-    pub struct r#w_97;
-    impl ::pest_typed::StringWrapper for r#w_97 {
+    pub struct r#w_103;
+    impl ::pest_typed::StringWrapper for r#w_103 {
         const CONTENT: &'static ::core::primitive::str = "[";
     }
     #[doc = "A wrapper for `\"]\"`."]
     #[allow(non_camel_case_types)]
     #[derive(Clone, Hash, PartialEq, Eq)]
-    pub struct r#w_98;
-    impl ::pest_typed::StringWrapper for r#w_98 {
+    pub struct r#w_104;
+    impl ::pest_typed::StringWrapper for r#w_104 {
         const CONTENT: &'static ::core::primitive::str = "]";
     }
     #[doc = "A wrapper for `\"(\"`."]
     #[allow(non_camel_case_types)]
     #[derive(Clone, Hash, PartialEq, Eq)]
-    pub struct r#w_99;
-    impl ::pest_typed::StringWrapper for r#w_99 {
+    pub struct r#w_105;
+    impl ::pest_typed::StringWrapper for r#w_105 {
         const CONTENT: &'static ::core::primitive::str = "(";
     }
     #[doc = "A wrapper for `\")\"`."]
     #[allow(non_camel_case_types)]
     #[derive(Clone, Hash, PartialEq, Eq)]
-    pub struct r#w_100;
-    impl ::pest_typed::StringWrapper for r#w_100 {
+    pub struct r#w_106;
+    impl ::pest_typed::StringWrapper for r#w_106 {
         const CONTENT: &'static ::core::primitive::str = ")";
     }
     #[doc = "A wrapper for `\"<\"`."]
     #[allow(non_camel_case_types)]
     #[derive(Clone, Hash, PartialEq, Eq)]
-    pub struct r#w_101;
-    impl ::pest_typed::StringWrapper for r#w_101 {
+    pub struct r#w_107;
+    impl ::pest_typed::StringWrapper for r#w_107 {
         const CONTENT: &'static ::core::primitive::str = "<";
     }
     #[doc = "A wrapper for `\">\"`."]
     #[allow(non_camel_case_types)]
     #[derive(Clone, Hash, PartialEq, Eq)]
-    pub struct r#w_102;
-    impl ::pest_typed::StringWrapper for r#w_102 {
+    pub struct r#w_108;
+    impl ::pest_typed::StringWrapper for r#w_108 {
         const CONTENT: &'static ::core::primitive::str = ">";
     }
     #[doc = "A wrapper for `\"$\"`."]
     #[allow(non_camel_case_types)]
     #[derive(Clone, Hash, PartialEq, Eq)]
-    pub struct r#w_103;
-    impl ::pest_typed::StringWrapper for r#w_103 {
+    pub struct r#w_109;
+    impl ::pest_typed::StringWrapper for r#w_109 {
         const CONTENT: &'static ::core::primitive::str = "$";
     }
     #[doc = "A wrapper for `\"=\"`."]
     #[allow(non_camel_case_types)]
     #[derive(Clone, Hash, PartialEq, Eq)]
-    pub struct r#w_104;
-    impl ::pest_typed::StringWrapper for r#w_104 {
+    pub struct r#w_110;
+    impl ::pest_typed::StringWrapper for r#w_110 {
         const CONTENT: &'static ::core::primitive::str = "=";
     }
     #[doc = "A wrapper for `\",\"`."]
     #[allow(non_camel_case_types)]
     #[derive(Clone, Hash, PartialEq, Eq)]
-    pub struct r#w_105;
-    impl ::pest_typed::StringWrapper for r#w_105 {
+    pub struct r#w_111;
+    impl ::pest_typed::StringWrapper for r#w_111 {
         const CONTENT: &'static ::core::primitive::str = ",";
     }
     #[doc = "A wrapper for `\".\"`."]
     #[allow(non_camel_case_types)]
     #[derive(Clone, Hash, PartialEq, Eq)]
-    pub struct r#w_106;
-    impl ::pest_typed::StringWrapper for r#w_106 {
+    pub struct r#w_112;
+    impl ::pest_typed::StringWrapper for r#w_112 {
         const CONTENT: &'static ::core::primitive::str = ".";
     }
     #[doc = "A wrapper for `\"..\"`."]
     #[allow(non_camel_case_types)]
     #[derive(Clone, Hash, PartialEq, Eq)]
-    pub struct r#w_107;
-    impl ::pest_typed::StringWrapper for r#w_107 {
+    pub struct r#w_113;
+    impl ::pest_typed::StringWrapper for r#w_113 {
         const CONTENT: &'static ::core::primitive::str = "..";
     }
     #[doc = "A wrapper for `\":\"`."]
     #[allow(non_camel_case_types)]
     #[derive(Clone, Hash, PartialEq, Eq)]
-    pub struct r#w_108;
-    impl ::pest_typed::StringWrapper for r#w_108 {
+    pub struct r#w_114;
+    impl ::pest_typed::StringWrapper for r#w_114 {
         const CONTENT: &'static ::core::primitive::str = ":";
     }
     #[doc = "A wrapper for `\"::\"`."]
     #[allow(non_camel_case_types)]
     #[derive(Clone, Hash, PartialEq, Eq)]
-    pub struct r#w_109;
-    impl ::pest_typed::StringWrapper for r#w_109 {
+    pub struct r#w_115;
+    impl ::pest_typed::StringWrapper for r#w_115 {
         const CONTENT: &'static ::core::primitive::str = "::";
     }
     #[doc = "A wrapper for `\";\"`."]
     #[allow(non_camel_case_types)]
     #[derive(Clone, Hash, PartialEq, Eq)]
-    pub struct r#w_110;
-    impl ::pest_typed::StringWrapper for r#w_110 {
+    pub struct r#w_116;
+    impl ::pest_typed::StringWrapper for r#w_116 {
         const CONTENT: &'static ::core::primitive::str = ";";
     }
     #[doc = "A wrapper for `\"#\"`."]
     #[allow(non_camel_case_types)]
     #[derive(Clone, Hash, PartialEq, Eq)]
-    pub struct r#w_111;
-    impl ::pest_typed::StringWrapper for r#w_111 {
+    pub struct r#w_117;
+    impl ::pest_typed::StringWrapper for r#w_117 {
         const CONTENT: &'static ::core::primitive::str = "#";
     }
     #[doc = "A wrapper for `\"&\"`."]
     #[allow(non_camel_case_types)]
     #[derive(Clone, Hash, PartialEq, Eq)]
-    pub struct r#w_112;
-    impl ::pest_typed::StringWrapper for r#w_112 {
+    pub struct r#w_118;
+    impl ::pest_typed::StringWrapper for r#w_118 {
         const CONTENT: &'static ::core::primitive::str = "&";
     }
     #[doc = "A wrapper for `\"&&\"`."]
     #[allow(non_camel_case_types)]
     #[derive(Clone, Hash, PartialEq, Eq)]
-    pub struct r#w_113;
-    impl ::pest_typed::StringWrapper for r#w_113 {
+    pub struct r#w_119;
+    impl ::pest_typed::StringWrapper for r#w_119 {
         const CONTENT: &'static ::core::primitive::str = "&&";
     }
     #[doc = "A wrapper for `\"||\"`."]
     #[allow(non_camel_case_types)]
     #[derive(Clone, Hash, PartialEq, Eq)]
-    pub struct r#w_114;
-    impl ::pest_typed::StringWrapper for r#w_114 {
+    pub struct r#w_120;
+    impl ::pest_typed::StringWrapper for r#w_120 {
         const CONTENT: &'static ::core::primitive::str = "||";
     }
     #[doc = "A wrapper for `\"!\"`."]
     #[allow(non_camel_case_types)]
     #[derive(Clone, Hash, PartialEq, Eq)]
-    pub struct r#w_115;
-    impl ::pest_typed::StringWrapper for r#w_115 {
+    pub struct r#w_121;
+    impl ::pest_typed::StringWrapper for r#w_121 {
         const CONTENT: &'static ::core::primitive::str = "!";
     }
     #[doc = "A wrapper for `\"?\"`."]
     #[allow(non_camel_case_types)]
     #[derive(Clone, Hash, PartialEq, Eq)]
-    pub struct r#w_116;
-    impl ::pest_typed::StringWrapper for r#w_116 {
+    pub struct r#w_122;
+    impl ::pest_typed::StringWrapper for r#w_122 {
         const CONTENT: &'static ::core::primitive::str = "?";
     }
     #[doc = "A wrapper for `\"*\"`."]
     #[allow(non_camel_case_types)]
     #[derive(Clone, Hash, PartialEq, Eq)]
-    pub struct r#w_117;
-    impl ::pest_typed::StringWrapper for r#w_117 {
+    pub struct r#w_123;
+    impl ::pest_typed::StringWrapper for r#w_123 {
         const CONTENT: &'static ::core::primitive::str = "*";
     }
     #[doc = "A wrapper for `\"->\"`."]
     #[allow(non_camel_case_types)]
     #[derive(Clone, Hash, PartialEq, Eq)]
-    pub struct r#w_118;
-    impl ::pest_typed::StringWrapper for r#w_118 {
+    pub struct r#w_124;
+    impl ::pest_typed::StringWrapper for r#w_124 {
         const CONTENT: &'static ::core::primitive::str = "->";
     }
     #[doc = "A wrapper for `\"=>\"`."]
     #[allow(non_camel_case_types)]
     #[derive(Clone, Hash, PartialEq, Eq)]
-    pub struct r#w_119;
-    impl ::pest_typed::StringWrapper for r#w_119 {
+    pub struct r#w_125;
+    impl ::pest_typed::StringWrapper for r#w_125 {
         const CONTENT: &'static ::core::primitive::str = "=>";
     }
     #[doc = "A wrapper for `\"'\"`."]
     #[allow(non_camel_case_types)]
     #[derive(Clone, Hash, PartialEq, Eq)]
-    pub struct r#w_120;
-    impl ::pest_typed::StringWrapper for r#w_120 {
+    pub struct r#w_126;
+    impl ::pest_typed::StringWrapper for r#w_126 {
         const CONTENT: &'static ::core::primitive::str = "'";
     }
     #[doc = "A wrapper for `\"+\"`."]
     #[allow(non_camel_case_types)]
     #[derive(Clone, Hash, PartialEq, Eq)]
-    pub struct r#w_121;
-    impl ::pest_typed::StringWrapper for r#w_121 {
+    pub struct r#w_127;
+    impl ::pest_typed::StringWrapper for r#w_127 {
         const CONTENT: &'static ::core::primitive::str = "+";
     }
     #[doc = "A wrapper for `\"-\"`."]
     #[allow(non_camel_case_types)]
     #[derive(Clone, Hash, PartialEq, Eq)]
-    pub struct r#w_122;
-    impl ::pest_typed::StringWrapper for r#w_122 {
-        const CONTENT: &'static ::core::primitive::str = "-";
-    }
-    #[doc = "A wrapper for `\"_\"`."]
-    #[allow(non_camel_case_types)]
-    #[derive(Clone, Hash, PartialEq, Eq)]
-    pub struct r#w_123;
-    impl ::pest_typed::StringWrapper for r#w_123 {
-        const CONTENT: &'static ::core::primitive::str = "_";
-    }
-    #[doc = "A wrapper for `\"_\"`."]
-    #[allow(non_camel_case_types)]
-    #[derive(Clone, Hash, PartialEq, Eq)]
-    pub struct r#w_124;
-    impl ::pest_typed::StringWrapper for r#w_124 {
-        const CONTENT: &'static ::core::primitive::str = "_";
-    }
-    #[doc = "A wrapper for `\"0b\"`."]
-    #[allow(non_camel_case_types)]
-    #[derive(Clone, Hash, PartialEq, Eq)]
-    pub struct r#w_125;
-    impl ::pest_typed::StringWrapper for r#w_125 {
-        const CONTENT: &'static ::core::primitive::str = "0b";
-    }
-    #[doc = "A wrapper for `\"_\"`."]
-    #[allow(non_camel_case_types)]
-    #[derive(Clone, Hash, PartialEq, Eq)]
-    pub struct r#w_126;
-    impl ::pest_typed::StringWrapper for r#w_126 {
-        const CONTENT: &'static ::core::primitive::str = "_";
-    }
-    #[doc = "A wrapper for `\"_\"`."]
-    #[allow(non_camel_case_types)]
-    #[derive(Clone, Hash, PartialEq, Eq)]
-    pub struct r#w_127;
-    impl ::pest_typed::StringWrapper for r#w_127 {
-        const CONTENT: &'static ::core::primitive::str = "_";
-    }
-    #[doc = "A wrapper for `\"0o\"`."]
-    #[allow(non_camel_case_types)]
-    #[derive(Clone, Hash, PartialEq, Eq)]
     pub struct r#w_128;
     impl ::pest_typed::StringWrapper for r#w_128 {
-        const CONTENT: &'static ::core::primitive::str = "0o";
+        const CONTENT: &'static ::core::primitive::str = "-";
     }
     #[doc = "A wrapper for `\"_\"`."]
     #[allow(non_camel_case_types)]
@@ -1224,12 +1230,12 @@ mod constant_wrappers {
     impl ::pest_typed::StringWrapper for r#w_130 {
         const CONTENT: &'static ::core::primitive::str = "_";
     }
-    #[doc = "A wrapper for `\"0x\"`."]
+    #[doc = "A wrapper for `\"0b\"`."]
     #[allow(non_camel_case_types)]
     #[derive(Clone, Hash, PartialEq, Eq)]
     pub struct r#w_131;
     impl ::pest_typed::StringWrapper for r#w_131 {
-        const CONTENT: &'static ::core::primitive::str = "0x";
+        const CONTENT: &'static ::core::primitive::str = "0b";
     }
     #[doc = "A wrapper for `\"_\"`."]
     #[allow(non_camel_case_types)]
@@ -1245,47 +1251,47 @@ mod constant_wrappers {
     impl ::pest_typed::StringWrapper for r#w_133 {
         const CONTENT: &'static ::core::primitive::str = "_";
     }
-    #[doc = "A wrapper for `\"\\\"\"`."]
+    #[doc = "A wrapper for `\"0o\"`."]
     #[allow(non_camel_case_types)]
     #[derive(Clone, Hash, PartialEq, Eq)]
     pub struct r#w_134;
     impl ::pest_typed::StringWrapper for r#w_134 {
-        const CONTENT: &'static ::core::primitive::str = "\"";
-    }
-    #[doc = "A wrapper for `[\"\\\"\"]`."]
-    #[allow(non_camel_case_types)]
-    #[derive(Clone, PartialEq)]
-    pub struct r#w_135;
-    impl ::pest_typed::StringArrayWrapper for r#w_135 {
-        const CONTENT: &'static [&'static ::core::primitive::str] = &["\""];
-    }
-    #[doc = "A wrapper for `\"\\\"\"`."]
-    #[allow(non_camel_case_types)]
-    #[derive(Clone, Hash, PartialEq, Eq)]
-    pub struct r#w_136;
-    impl ::pest_typed::StringWrapper for r#w_136 {
-        const CONTENT: &'static ::core::primitive::str = "\"";
+        const CONTENT: &'static ::core::primitive::str = "0o";
     }
     #[doc = "A wrapper for `\"_\"`."]
     #[allow(non_camel_case_types)]
     #[derive(Clone, Hash, PartialEq, Eq)]
-    pub struct r#w_137;
-    impl ::pest_typed::StringWrapper for r#w_137 {
+    pub struct r#w_135;
+    impl ::pest_typed::StringWrapper for r#w_135 {
         const CONTENT: &'static ::core::primitive::str = "_";
     }
-    #[doc = "A wrapper for `\"-\"`."]
+    #[doc = "A wrapper for `\"_\"`."]
+    #[allow(non_camel_case_types)]
+    #[derive(Clone, Hash, PartialEq, Eq)]
+    pub struct r#w_136;
+    impl ::pest_typed::StringWrapper for r#w_136 {
+        const CONTENT: &'static ::core::primitive::str = "_";
+    }
+    #[doc = "A wrapper for `\"0x\"`."]
+    #[allow(non_camel_case_types)]
+    #[derive(Clone, Hash, PartialEq, Eq)]
+    pub struct r#w_137;
+    impl ::pest_typed::StringWrapper for r#w_137 {
+        const CONTENT: &'static ::core::primitive::str = "0x";
+    }
+    #[doc = "A wrapper for `\"_\"`."]
     #[allow(non_camel_case_types)]
     #[derive(Clone, Hash, PartialEq, Eq)]
     pub struct r#w_138;
     impl ::pest_typed::StringWrapper for r#w_138 {
-        const CONTENT: &'static ::core::primitive::str = "-";
+        const CONTENT: &'static ::core::primitive::str = "_";
     }
-    #[doc = "A wrapper for `\"Group\"`."]
+    #[doc = "A wrapper for `\"_\"`."]
     #[allow(non_camel_case_types)]
     #[derive(Clone, Hash, PartialEq, Eq)]
     pub struct r#w_139;
     impl ::pest_typed::StringWrapper for r#w_139 {
-        const CONTENT: &'static ::core::primitive::str = "Group";
+        const CONTENT: &'static ::core::primitive::str = "_";
     }
     #[doc = "A wrapper for `\"\\\"\"`."]
     #[allow(non_camel_case_types)]
@@ -1294,18 +1300,60 @@ mod constant_wrappers {
     impl ::pest_typed::StringWrapper for r#w_140 {
         const CONTENT: &'static ::core::primitive::str = "\"";
     }
-    #[doc = "A wrapper for `\"\\\"\"`."]
+    #[doc = "A wrapper for `[\"\\\"\"]`."]
     #[allow(non_camel_case_types)]
-    #[derive(Clone, Hash, PartialEq, Eq)]
+    #[derive(Clone, PartialEq)]
     pub struct r#w_141;
-    impl ::pest_typed::StringWrapper for r#w_141 {
-        const CONTENT: &'static ::core::primitive::str = "\"";
+    impl ::pest_typed::StringArrayWrapper for r#w_141 {
+        const CONTENT: &'static [&'static ::core::primitive::str] = &["\""];
     }
     #[doc = "A wrapper for `\"\\\"\"`."]
     #[allow(non_camel_case_types)]
     #[derive(Clone, Hash, PartialEq, Eq)]
     pub struct r#w_142;
     impl ::pest_typed::StringWrapper for r#w_142 {
+        const CONTENT: &'static ::core::primitive::str = "\"";
+    }
+    #[doc = "A wrapper for `\"_\"`."]
+    #[allow(non_camel_case_types)]
+    #[derive(Clone, Hash, PartialEq, Eq)]
+    pub struct r#w_143;
+    impl ::pest_typed::StringWrapper for r#w_143 {
+        const CONTENT: &'static ::core::primitive::str = "_";
+    }
+    #[doc = "A wrapper for `\"-\"`."]
+    #[allow(non_camel_case_types)]
+    #[derive(Clone, Hash, PartialEq, Eq)]
+    pub struct r#w_144;
+    impl ::pest_typed::StringWrapper for r#w_144 {
+        const CONTENT: &'static ::core::primitive::str = "-";
+    }
+    #[doc = "A wrapper for `\"Group\"`."]
+    #[allow(non_camel_case_types)]
+    #[derive(Clone, Hash, PartialEq, Eq)]
+    pub struct r#w_145;
+    impl ::pest_typed::StringWrapper for r#w_145 {
+        const CONTENT: &'static ::core::primitive::str = "Group";
+    }
+    #[doc = "A wrapper for `\"\\\"\"`."]
+    #[allow(non_camel_case_types)]
+    #[derive(Clone, Hash, PartialEq, Eq)]
+    pub struct r#w_146;
+    impl ::pest_typed::StringWrapper for r#w_146 {
+        const CONTENT: &'static ::core::primitive::str = "\"";
+    }
+    #[doc = "A wrapper for `\"\\\"\"`."]
+    #[allow(non_camel_case_types)]
+    #[derive(Clone, Hash, PartialEq, Eq)]
+    pub struct r#w_147;
+    impl ::pest_typed::StringWrapper for r#w_147 {
+        const CONTENT: &'static ::core::primitive::str = "\"";
+    }
+    #[doc = "A wrapper for `\"\\\"\"`."]
+    #[allow(non_camel_case_types)]
+    #[derive(Clone, Hash, PartialEq, Eq)]
+    pub struct r#w_148;
+    impl ::pest_typed::StringWrapper for r#w_148 {
         const CONTENT: &'static ::core::primitive::str = "\"";
     }
 }
@@ -1491,8 +1539,59 @@ pub mod rules_impl {
         impl<'i, const INHERITED: ::core::primitive::usize> r#kw_str<'i, INHERITED> {}
         :: pest_typed :: rule ! (r#Keywords , "Corresponds to expression: `(kw_pattern | kw_patt | kw_util | kw_cstr | kw_diag | kw_meta | kw_import | kw_self | kw_Self | kw_fn | kw_mut | kw_const | kw_static | kw_lang | kw_as | kw_crate | kw_use | kw_type | kw_let | kw_move | kw_Len | kw_PtrToPtr | kw_IntToInt | kw_Transmute | kw_PointerCoercion | kw_PointerExposeProvenance | kw_PointerWithExposedProvenance | kw_Add | kw_Sub | kw_Mul | kw_Div | kw_Rem | kw_Lt | kw_Le | kw_Gt | kw_Ge | kw_Eq | kw_Ne | kw_BitAnd | kw_BitOr | kw_BitXor | kw_Offset | kw_SizeOf | kw_AlignOf | kw_Neg | kw_Not | kw_PtrMetadata | kw_discriminant | kw_copy_nonoverlapping | kw_Ctor | kw_from | kw_of | kw_raw | kw_break | kw_continue | kw_loop | kw_return | kw_switchInt | kw_true | kw_false | kw_unsafe | kw_pub | kw_struct | kw_enum | kw_impl | kw_for | kw_where)`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#Keywords , super :: super :: generics :: Choice67 :: < super :: super :: rules :: r#kw_pattern :: < 'i , 0 > , super :: super :: rules :: r#kw_patt :: < 'i , 0 > , super :: super :: rules :: r#kw_util :: < 'i , 0 > , super :: super :: rules :: r#kw_cstr :: < 'i , 0 > , super :: super :: rules :: r#kw_diag :: < 'i , 0 > , super :: super :: rules :: r#kw_meta :: < 'i , 0 > , super :: super :: rules :: r#kw_import :: < 'i , 0 > , super :: super :: rules :: r#kw_self :: < 'i , 0 > , super :: super :: rules :: r#kw_Self :: < 'i , 0 > , super :: super :: rules :: r#kw_fn :: < 'i , 0 > , super :: super :: rules :: r#kw_mut :: < 'i , 0 > , super :: super :: rules :: r#kw_const :: < 'i , 0 > , super :: super :: rules :: r#kw_static :: < 'i , 0 > , super :: super :: rules :: r#kw_lang :: < 'i , 0 > , super :: super :: rules :: r#kw_as :: < 'i , 0 > , super :: super :: rules :: r#kw_crate :: < 'i , 0 > , super :: super :: rules :: r#kw_use :: < 'i , 0 > , super :: super :: rules :: r#kw_type :: < 'i , 0 > , super :: super :: rules :: r#kw_let :: < 'i , 0 > , super :: super :: rules :: r#kw_move :: < 'i , 0 > , super :: super :: rules :: r#kw_Len :: < 'i , 0 > , super :: super :: rules :: r#kw_PtrToPtr :: < 'i , 0 > , super :: super :: rules :: r#kw_IntToInt :: < 'i , 0 > , super :: super :: rules :: r#kw_Transmute :: < 'i , 0 > , super :: super :: rules :: r#kw_PointerCoercion :: < 'i , 0 > , super :: super :: rules :: r#kw_PointerExposeProvenance :: < 'i , 0 > , super :: super :: rules :: r#kw_PointerWithExposedProvenance :: < 'i , 0 > , super :: super :: rules :: r#kw_Add :: < 'i , 0 > , super :: super :: rules :: r#kw_Sub :: < 'i , 0 > , super :: super :: rules :: r#kw_Mul :: < 'i , 0 > , super :: super :: rules :: r#kw_Div :: < 'i , 0 > , super :: super :: rules :: r#kw_Rem :: < 'i , 0 > , super :: super :: rules :: r#kw_Lt :: < 'i , 0 > , super :: super :: rules :: r#kw_Le :: < 'i , 0 > , super :: super :: rules :: r#kw_Gt :: < 'i , 0 > , super :: super :: rules :: r#kw_Ge :: < 'i , 0 > , super :: super :: rules :: r#kw_Eq :: < 'i , 0 > , super :: super :: rules :: r#kw_Ne :: < 'i , 0 > , super :: super :: rules :: r#kw_BitAnd :: < 'i , 0 > , super :: super :: rules :: r#kw_BitOr :: < 'i , 0 > , super :: super :: rules :: r#kw_BitXor :: < 'i , 0 > , super :: super :: rules :: r#kw_Offset :: < 'i , 0 > , super :: super :: rules :: r#kw_SizeOf :: < 'i , 0 > , super :: super :: rules :: r#kw_AlignOf :: < 'i , 0 > , super :: super :: rules :: r#kw_Neg :: < 'i , 0 > , super :: super :: rules :: r#kw_Not :: < 'i , 0 > , super :: super :: rules :: r#kw_PtrMetadata :: < 'i , 0 > , super :: super :: rules :: r#kw_discriminant :: < 'i , 0 > , super :: super :: rules :: r#kw_copy_nonoverlapping :: < 'i , 0 > , super :: super :: rules :: r#kw_Ctor :: < 'i , 0 > , super :: super :: rules :: r#kw_from :: < 'i , 0 > , super :: super :: rules :: r#kw_of :: < 'i , 0 > , super :: super :: rules :: r#kw_raw :: < 'i , 0 > , super :: super :: rules :: r#kw_break :: < 'i , 0 > , super :: super :: rules :: r#kw_continue :: < 'i , 0 > , super :: super :: rules :: r#kw_loop :: < 'i , 0 > , super :: super :: rules :: r#kw_return :: < 'i , 0 > , super :: super :: rules :: r#kw_switchInt :: < 'i , 0 > , super :: super :: rules :: r#kw_true :: < 'i , 0 > , super :: super :: rules :: r#kw_false :: < 'i , 0 > , super :: super :: rules :: r#kw_unsafe :: < 'i , 0 > , super :: super :: rules :: r#kw_pub :: < 'i , 0 > , super :: super :: rules :: r#kw_struct :: < 'i , 0 > , super :: super :: rules :: r#kw_enum :: < 'i , 0 > , super :: super :: rules :: r#kw_impl :: < 'i , 0 > , super :: super :: rules :: r#kw_for :: < 'i , 0 > , super :: super :: rules :: r#kw_where :: < 'i , 0 > , > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
         impl<'i, const INHERITED: ::core::primitive::usize> r#Keywords<'i, INHERITED> {}
-        :: pest_typed :: rule ! (r#COMMENT , "Corresponds to expression: `((\"//\" ~ (!NEWLINE ~ ANY)*) | (\"/*\" ~ (!\"*/\" ~ ANY)* ~ \"*/\"))`. Normal rule." "" , super :: super :: Rule , super :: super :: Rule :: r#COMMENT , super :: super :: generics :: Choice2 :: < super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_87 > , super :: super :: generics :: Skipped < 'i > , INHERITED >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Rep :: < 'i , INHERITED , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Negative :: < super :: super :: rules :: r#NEWLINE > , super :: super :: generics :: Skipped < 'i > , INHERITED >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: rules :: r#ANY , super :: super :: generics :: Skipped < 'i > , INHERITED >) , > > , super :: super :: generics :: Skipped < 'i > , INHERITED >) , > , super :: super :: generics :: Seq3 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_88 > , super :: super :: generics :: Skipped < 'i > , INHERITED >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Rep :: < 'i , INHERITED , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Negative :: < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_89 > > , super :: super :: generics :: Skipped < 'i > , INHERITED >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: rules :: r#ANY , super :: super :: generics :: Skipped < 'i > , INHERITED >) , > > , super :: super :: generics :: Skipped < 'i > , INHERITED >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_90 > , super :: super :: generics :: Skipped < 'i > , INHERITED >) , > , > , super :: super :: generics :: Skipped :: < 'i > , INHERITED , Expression , true);
-        impl<'i, const INHERITED: ::core::primitive::usize> r#COMMENT<'i, INHERITED> {
+        :: pest_typed :: rule ! (r#DocComment , "Corresponds to expression: `(OuterDocComment | InnerDocComment)`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#DocComment , super :: super :: generics :: Choice2 :: < super :: super :: rules :: r#OuterDocComment :: < 'i , 0 > , super :: super :: rules :: r#InnerDocComment :: < 'i , 0 > , > , super :: super :: generics :: Skipped :: < 'i > , true , Both , true);
+        impl<'i, const INHERITED: ::core::primitive::usize> r#DocComment<'i, INHERITED> {
+            #[doc = "A helper function to access [`InnerDocComment`]."]
+            #[allow(non_snake_case)]
+            pub fn r#InnerDocComment<'s>(
+                &'s self,
+            ) -> ::pest_typed::re_exported::Option<&'s super::super::rules::r#InnerDocComment<'i, 0>> {
+                let res = &*self.content;
+                {
+                    let res = res._1().map(|res| res);
+                    res
+                }
+            }
+            #[doc = "A helper function to access [`OuterDocComment`]."]
+            #[allow(non_snake_case)]
+            pub fn r#OuterDocComment<'s>(
+                &'s self,
+            ) -> ::pest_typed::re_exported::Option<&'s super::super::rules::r#OuterDocComment<'i, 0>> {
+                let res = &*self.content;
+                {
+                    let res = res._0().map(|res| res);
+                    res
+                }
+            }
+        }
+        :: pest_typed :: rule ! (r#OuterDocComment , "Corresponds to expression: `(\"///\" ~ !\"/\" ~ DocCommentText)`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#OuterDocComment , super :: super :: generics :: Seq3 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_87 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Negative :: < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_88 > > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: rules :: r#DocCommentText :: < 'i , 0 > , super :: super :: generics :: Skipped < 'i > , 0 >) , > , super :: super :: generics :: Skipped :: < 'i > , true , Both , true);
+        impl<'i, const INHERITED: ::core::primitive::usize> r#OuterDocComment<'i, INHERITED> {
+            #[doc = "A helper function to access [`DocCommentText`]."]
+            #[allow(non_snake_case)]
+            pub fn r#DocCommentText<'s>(&'s self) -> &'s super::super::rules::r#DocCommentText<'i, 0> {
+                let res = &*self.content;
+                {
+                    let res = &res.content.2.matched;
+                    res
+                }
+            }
+        }
+        :: pest_typed :: rule ! (r#InnerDocComment , "Corresponds to expression: `(\"//!\" ~ DocCommentText)`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#InnerDocComment , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_89 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: rules :: r#DocCommentText :: < 'i , 0 > , super :: super :: generics :: Skipped < 'i > , 0 >) , > , super :: super :: generics :: Skipped :: < 'i > , true , Both , true);
+        impl<'i, const INHERITED: ::core::primitive::usize> r#InnerDocComment<'i, INHERITED> {
+            #[doc = "A helper function to access [`DocCommentText`]."]
+            #[allow(non_snake_case)]
+            pub fn r#DocCommentText<'s>(&'s self) -> &'s super::super::rules::r#DocCommentText<'i, 0> {
+                let res = &*self.content;
+                {
+                    let res = &res.content.1.matched;
+                    res
+                }
+            }
+        }
+        :: pest_typed :: rule ! (r#DocCommentText , "Corresponds to expression: `(!NEWLINE ~ ANY)*`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#DocCommentText , super :: super :: generics :: Rep :: < 'i , 0 , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Negative :: < super :: super :: rules :: r#NEWLINE > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: rules :: r#ANY , super :: super :: generics :: Skipped < 'i > , 0 >) , > > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
+        impl<'i, const INHERITED: ::core::primitive::usize> r#DocCommentText<'i, INHERITED> {}
+        :: pest_typed :: rule ! (r#LineCommentNonDoc , "Corresponds to expression: `((\"//\" ~ !(\"/\" | \"!\") ~ (!NEWLINE ~ ANY)*) | (\"////\" ~ (!NEWLINE ~ ANY)*))`. Normal rule." "" , super :: super :: Rule , super :: super :: Rule :: r#LineCommentNonDoc , super :: super :: generics :: Choice2 :: < super :: super :: generics :: Seq3 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_90 > , super :: super :: generics :: Skipped < 'i > , INHERITED >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Negative :: < super :: super :: generics :: Choice2 :: < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_91 > , super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_92 > , > > , super :: super :: generics :: Skipped < 'i > , INHERITED >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Rep :: < 'i , INHERITED , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Negative :: < super :: super :: rules :: r#NEWLINE > , super :: super :: generics :: Skipped < 'i > , INHERITED >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: rules :: r#ANY , super :: super :: generics :: Skipped < 'i > , INHERITED >) , > > , super :: super :: generics :: Skipped < 'i > , INHERITED >) , > , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_93 > , super :: super :: generics :: Skipped < 'i > , INHERITED >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Rep :: < 'i , INHERITED , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Negative :: < super :: super :: rules :: r#NEWLINE > , super :: super :: generics :: Skipped < 'i > , INHERITED >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: rules :: r#ANY , super :: super :: generics :: Skipped < 'i > , INHERITED >) , > > , super :: super :: generics :: Skipped < 'i > , INHERITED >) , > , > , super :: super :: generics :: Skipped :: < 'i > , INHERITED , Expression , true);
+        impl<'i, const INHERITED: ::core::primitive::usize> r#LineCommentNonDoc<'i, INHERITED> {
             #[doc = "A helper function to access [`ANY`]."]
             #[allow(non_snake_case)]
             pub fn r#ANY<'s>(
@@ -1506,7 +1605,7 @@ pub mod rules_impl {
                     let res = (
                         {
                             let res = res._0().map(|res| {
-                                let res = &res.content.1.matched;
+                                let res = &res.content.2.matched;
                                 {
                                     let res = res
                                         .content
@@ -1549,65 +1648,116 @@ pub mod rules_impl {
                 }
             }
         }
-        :: pest_typed :: rule ! (r#WHITESPACE , "Corresponds to expression: `(\" \" | \"\\t\" | \"\\r\" | \"\\n\")`. Normal rule." "" , super :: super :: Rule , super :: super :: Rule :: r#WHITESPACE , super :: super :: generics :: Choice4 :: < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_91 > , super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_92 > , super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_93 > , super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_94 > , > , super :: super :: generics :: Skipped :: < 'i > , INHERITED , Expression , true);
+        :: pest_typed :: rule ! (r#BlockComment , "Corresponds to expression: `(\"/*\" ~ (!\"*/\" ~ ANY)* ~ \"*/\")`. Normal rule." "" , super :: super :: Rule , super :: super :: Rule :: r#BlockComment , super :: super :: generics :: Seq3 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_94 > , super :: super :: generics :: Skipped < 'i > , INHERITED >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Rep :: < 'i , INHERITED , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Negative :: < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_95 > > , super :: super :: generics :: Skipped < 'i > , INHERITED >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: rules :: r#ANY , super :: super :: generics :: Skipped < 'i > , INHERITED >) , > > , super :: super :: generics :: Skipped < 'i > , INHERITED >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_96 > , super :: super :: generics :: Skipped < 'i > , INHERITED >) , > , super :: super :: generics :: Skipped :: < 'i > , INHERITED , Expression , true);
+        impl<'i, const INHERITED: ::core::primitive::usize> r#BlockComment<'i, INHERITED> {
+            #[doc = "A helper function to access [`ANY`]."]
+            #[allow(non_snake_case)]
+            pub fn r#ANY<'s>(&'s self) -> ::pest_typed::re_exported::Vec<&'s super::super::rules::r#ANY> {
+                let res = &*self.content;
+                {
+                    let res = &res.content.1.matched;
+                    {
+                        let res = res
+                            .content
+                            .iter()
+                            .map(|res| {
+                                let res = &res.matched;
+                                {
+                                    let res = &res.content.1.matched;
+                                    res
+                                }
+                            })
+                            .collect::<::pest_typed::re_exported::Vec<_>>();
+                        res
+                    }
+                }
+            }
+        }
+        :: pest_typed :: rule ! (r#COMMENT , "Corresponds to expression: `(LineCommentNonDoc | BlockComment)`. Normal rule." "" , super :: super :: Rule , super :: super :: Rule :: r#COMMENT , super :: super :: generics :: Choice2 :: < super :: super :: rules :: r#LineCommentNonDoc :: < 'i , INHERITED > , super :: super :: rules :: r#BlockComment :: < 'i , INHERITED > , > , super :: super :: generics :: Skipped :: < 'i > , INHERITED , Expression , true);
+        impl<'i, const INHERITED: ::core::primitive::usize> r#COMMENT<'i, INHERITED> {
+            #[doc = "A helper function to access [`BlockComment`]."]
+            #[allow(non_snake_case)]
+            pub fn r#BlockComment<'s>(
+                &'s self,
+            ) -> ::pest_typed::re_exported::Option<&'s super::super::rules::r#BlockComment<'i, INHERITED>> {
+                let res = &*self.content;
+                {
+                    let res = res._1().map(|res| res);
+                    res
+                }
+            }
+            #[doc = "A helper function to access [`LineCommentNonDoc`]."]
+            #[allow(non_snake_case)]
+            pub fn r#LineCommentNonDoc<'s>(
+                &'s self,
+            ) -> ::pest_typed::re_exported::Option<&'s super::super::rules::r#LineCommentNonDoc<'i, INHERITED>>
+            {
+                let res = &*self.content;
+                {
+                    let res = res._0().map(|res| res);
+                    res
+                }
+            }
+        }
+        :: pest_typed :: rule ! (r#WHITESPACE , "Corresponds to expression: `(\" \" | \"\\t\" | \"\\r\" | \"\\n\")`. Normal rule." "" , super :: super :: Rule , super :: super :: Rule :: r#WHITESPACE , super :: super :: generics :: Choice4 :: < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_97 > , super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_98 > , super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_99 > , super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_100 > , > , super :: super :: generics :: Skipped :: < 'i > , INHERITED , Expression , true);
         impl<'i, const INHERITED: ::core::primitive::usize> r#WHITESPACE<'i, INHERITED> {}
-        :: pest_typed :: rule ! (r#LeftBrace , "Corresponds to expression: `\"{\"`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#LeftBrace , super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_95 > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
+        :: pest_typed :: rule ! (r#LeftBrace , "Corresponds to expression: `\"{\"`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#LeftBrace , super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_101 > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
         impl<'i, const INHERITED: ::core::primitive::usize> r#LeftBrace<'i, INHERITED> {}
-        :: pest_typed :: rule ! (r#RightBrace , "Corresponds to expression: `\"}\"`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#RightBrace , super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_96 > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
+        :: pest_typed :: rule ! (r#RightBrace , "Corresponds to expression: `\"}\"`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#RightBrace , super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_102 > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
         impl<'i, const INHERITED: ::core::primitive::usize> r#RightBrace<'i, INHERITED> {}
-        :: pest_typed :: rule ! (r#LeftBracket , "Corresponds to expression: `\"[\"`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#LeftBracket , super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_97 > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
+        :: pest_typed :: rule ! (r#LeftBracket , "Corresponds to expression: `\"[\"`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#LeftBracket , super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_103 > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
         impl<'i, const INHERITED: ::core::primitive::usize> r#LeftBracket<'i, INHERITED> {}
-        :: pest_typed :: rule ! (r#RightBracket , "Corresponds to expression: `\"]\"`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#RightBracket , super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_98 > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
+        :: pest_typed :: rule ! (r#RightBracket , "Corresponds to expression: `\"]\"`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#RightBracket , super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_104 > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
         impl<'i, const INHERITED: ::core::primitive::usize> r#RightBracket<'i, INHERITED> {}
-        :: pest_typed :: rule ! (r#LeftParen , "Corresponds to expression: `\"(\"`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#LeftParen , super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_99 > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
+        :: pest_typed :: rule ! (r#LeftParen , "Corresponds to expression: `\"(\"`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#LeftParen , super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_105 > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
         impl<'i, const INHERITED: ::core::primitive::usize> r#LeftParen<'i, INHERITED> {}
-        :: pest_typed :: rule ! (r#RightParen , "Corresponds to expression: `\")\"`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#RightParen , super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_100 > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
+        :: pest_typed :: rule ! (r#RightParen , "Corresponds to expression: `\")\"`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#RightParen , super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_106 > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
         impl<'i, const INHERITED: ::core::primitive::usize> r#RightParen<'i, INHERITED> {}
-        :: pest_typed :: rule ! (r#LessThan , "Corresponds to expression: `\"<\"`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#LessThan , super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_101 > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
+        :: pest_typed :: rule ! (r#LessThan , "Corresponds to expression: `\"<\"`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#LessThan , super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_107 > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
         impl<'i, const INHERITED: ::core::primitive::usize> r#LessThan<'i, INHERITED> {}
-        :: pest_typed :: rule ! (r#GreaterThan , "Corresponds to expression: `\">\"`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#GreaterThan , super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_102 > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
+        :: pest_typed :: rule ! (r#GreaterThan , "Corresponds to expression: `\">\"`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#GreaterThan , super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_108 > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
         impl<'i, const INHERITED: ::core::primitive::usize> r#GreaterThan<'i, INHERITED> {}
-        :: pest_typed :: rule ! (r#Dollar , "Corresponds to expression: `\"$\"`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#Dollar , super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_103 > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
+        :: pest_typed :: rule ! (r#Dollar , "Corresponds to expression: `\"$\"`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#Dollar , super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_109 > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
         impl<'i, const INHERITED: ::core::primitive::usize> r#Dollar<'i, INHERITED> {}
-        :: pest_typed :: rule ! (r#Assign , "Corresponds to expression: `\"=\"`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#Assign , super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_104 > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
+        :: pest_typed :: rule ! (r#Assign , "Corresponds to expression: `\"=\"`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#Assign , super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_110 > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
         impl<'i, const INHERITED: ::core::primitive::usize> r#Assign<'i, INHERITED> {}
-        :: pest_typed :: rule ! (r#Comma , "Corresponds to expression: `\",\"`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#Comma , super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_105 > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
+        :: pest_typed :: rule ! (r#Comma , "Corresponds to expression: `\",\"`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#Comma , super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_111 > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
         impl<'i, const INHERITED: ::core::primitive::usize> r#Comma<'i, INHERITED> {}
-        :: pest_typed :: rule ! (r#Dot , "Corresponds to expression: `\".\"`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#Dot , super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_106 > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
+        :: pest_typed :: rule ! (r#Dot , "Corresponds to expression: `\".\"`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#Dot , super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_112 > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
         impl<'i, const INHERITED: ::core::primitive::usize> r#Dot<'i, INHERITED> {}
-        :: pest_typed :: rule ! (r#Dot2 , "Corresponds to expression: `\"..\"`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#Dot2 , super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_107 > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
+        :: pest_typed :: rule ! (r#Dot2 , "Corresponds to expression: `\"..\"`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#Dot2 , super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_113 > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
         impl<'i, const INHERITED: ::core::primitive::usize> r#Dot2<'i, INHERITED> {}
-        :: pest_typed :: rule ! (r#Colon , "Corresponds to expression: `\":\"`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#Colon , super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_108 > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
+        :: pest_typed :: rule ! (r#Colon , "Corresponds to expression: `\":\"`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#Colon , super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_114 > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
         impl<'i, const INHERITED: ::core::primitive::usize> r#Colon<'i, INHERITED> {}
-        :: pest_typed :: rule ! (r#Colon2 , "Corresponds to expression: `\"::\"`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#Colon2 , super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_109 > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
+        :: pest_typed :: rule ! (r#Colon2 , "Corresponds to expression: `\"::\"`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#Colon2 , super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_115 > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
         impl<'i, const INHERITED: ::core::primitive::usize> r#Colon2<'i, INHERITED> {}
-        :: pest_typed :: rule ! (r#SemiColon , "Corresponds to expression: `\";\"`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#SemiColon , super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_110 > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
+        :: pest_typed :: rule ! (r#SemiColon , "Corresponds to expression: `\";\"`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#SemiColon , super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_116 > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
         impl<'i, const INHERITED: ::core::primitive::usize> r#SemiColon<'i, INHERITED> {}
-        :: pest_typed :: rule ! (r#Hash , "Corresponds to expression: `\"#\"`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#Hash , super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_111 > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
+        :: pest_typed :: rule ! (r#Hash , "Corresponds to expression: `\"#\"`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#Hash , super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_117 > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
         impl<'i, const INHERITED: ::core::primitive::usize> r#Hash<'i, INHERITED> {}
-        :: pest_typed :: rule ! (r#And , "Corresponds to expression: `\"&\"`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#And , super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_112 > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
+        :: pest_typed :: rule ! (r#And , "Corresponds to expression: `\"&\"`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#And , super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_118 > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
         impl<'i, const INHERITED: ::core::primitive::usize> r#And<'i, INHERITED> {}
-        :: pest_typed :: rule ! (r#AndAnd , "Corresponds to expression: `\"&&\"`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#AndAnd , super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_113 > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
+        :: pest_typed :: rule ! (r#AndAnd , "Corresponds to expression: `\"&&\"`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#AndAnd , super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_119 > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
         impl<'i, const INHERITED: ::core::primitive::usize> r#AndAnd<'i, INHERITED> {}
-        :: pest_typed :: rule ! (r#OrOr , "Corresponds to expression: `\"||\"`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#OrOr , super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_114 > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
+        :: pest_typed :: rule ! (r#OrOr , "Corresponds to expression: `\"||\"`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#OrOr , super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_120 > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
         impl<'i, const INHERITED: ::core::primitive::usize> r#OrOr<'i, INHERITED> {}
-        :: pest_typed :: rule ! (r#Bang , "Corresponds to expression: `\"!\"`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#Bang , super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_115 > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
+        :: pest_typed :: rule ! (r#Bang , "Corresponds to expression: `\"!\"`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#Bang , super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_121 > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
         impl<'i, const INHERITED: ::core::primitive::usize> r#Bang<'i, INHERITED> {}
-        :: pest_typed :: rule ! (r#Question , "Corresponds to expression: `\"?\"`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#Question , super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_116 > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
+        :: pest_typed :: rule ! (r#Question , "Corresponds to expression: `\"?\"`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#Question , super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_122 > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
         impl<'i, const INHERITED: ::core::primitive::usize> r#Question<'i, INHERITED> {}
-        :: pest_typed :: rule ! (r#Star , "Corresponds to expression: `\"*\"`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#Star , super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_117 > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
+        :: pest_typed :: rule ! (r#Star , "Corresponds to expression: `\"*\"`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#Star , super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_123 > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
         impl<'i, const INHERITED: ::core::primitive::usize> r#Star<'i, INHERITED> {}
-        :: pest_typed :: rule ! (r#Arrow , "Corresponds to expression: `\"->\"`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#Arrow , super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_118 > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
+        :: pest_typed :: rule ! (r#Arrow , "Corresponds to expression: `\"->\"`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#Arrow , super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_124 > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
         impl<'i, const INHERITED: ::core::primitive::usize> r#Arrow<'i, INHERITED> {}
-        :: pest_typed :: rule ! (r#RightArrow , "Corresponds to expression: `\"=>\"`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#RightArrow , super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_119 > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
+        :: pest_typed :: rule ! (r#RightArrow , "Corresponds to expression: `\"=>\"`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#RightArrow , super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_125 > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
         impl<'i, const INHERITED: ::core::primitive::usize> r#RightArrow<'i, INHERITED> {}
-        :: pest_typed :: rule ! (r#Quote , "Corresponds to expression: `\"'\"`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#Quote , super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_120 > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
+        :: pest_typed :: rule ! (r#Quote , "Corresponds to expression: `\"'\"`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#Quote , super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_126 > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
         impl<'i, const INHERITED: ::core::primitive::usize> r#Quote<'i, INHERITED> {}
-        :: pest_typed :: rule ! (r#Plus , "Corresponds to expression: `\"+\"`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#Plus , super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_121 > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
+        :: pest_typed :: rule ! (r#Plus , "Corresponds to expression: `\"+\"`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#Plus , super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_127 > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
         impl<'i, const INHERITED: ::core::primitive::usize> r#Plus<'i, INHERITED> {}
-        :: pest_typed :: rule ! (r#Minus , "Corresponds to expression: `\"-\"`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#Minus , super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_122 > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
+        :: pest_typed :: rule ! (r#Minus , "Corresponds to expression: `\"-\"`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#Minus , super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_128 > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
         impl<'i, const INHERITED: ::core::primitive::usize> r#Minus<'i, INHERITED> {}
-        :: pest_typed :: rule ! (r#PlaceHolder , "Corresponds to expression: `\"_\"`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#PlaceHolder , super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_123 > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
+        :: pest_typed :: rule ! (r#PlaceHolder , "Corresponds to expression: `\"_\"`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#PlaceHolder , super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_129 > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
         impl<'i, const INHERITED: ::core::primitive::usize> r#PlaceHolder<'i, INHERITED> {}
         :: pest_typed :: rule ! (r#Literal , "Corresponds to expression: `(Integer | String | Bool)`. Normal rule." "" , super :: super :: Rule , super :: super :: Rule :: r#Literal , super :: super :: generics :: Choice3 :: < super :: super :: rules :: r#Integer :: < 'i , INHERITED > , super :: super :: rules :: r#String :: < 'i , INHERITED > , super :: super :: rules :: r#Bool :: < 'i , INHERITED > , > , super :: super :: generics :: Skipped :: < 'i > , INHERITED , Both , true);
         impl<'i, const INHERITED: ::core::primitive::usize> r#Literal<'i, INHERITED> {
@@ -1653,13 +1803,13 @@ pub mod rules_impl {
         impl<'i, const INHERITED: ::core::primitive::usize> r#DEC_DIGIT<'i, INHERITED> {}
         :: pest_typed :: rule ! (r#HEX_DIGIT , "Corresponds to expression: `(('0'..'9') | ('a'..'f') | ('A'..'F'))`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#HEX_DIGIT , super :: super :: generics :: Choice3 :: < super :: super :: generics :: CharRange :: < '0' , '9' > , super :: super :: generics :: CharRange :: < 'a' , 'f' > , super :: super :: generics :: CharRange :: < 'A' , 'F' > , > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
         impl<'i, const INHERITED: ::core::primitive::usize> r#HEX_DIGIT<'i, INHERITED> {}
-        :: pest_typed :: rule ! (r#DEC_LITERAL , "Corresponds to expression: `(DEC_DIGIT ~ (DEC_DIGIT | \"_\")*)`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#DEC_LITERAL , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: rules :: r#DEC_DIGIT :: < 'i , 0 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Rep :: < 'i , 0 , super :: super :: generics :: Choice2 :: < super :: super :: rules :: r#DEC_DIGIT :: < 'i , 0 > , super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_124 > , > > , super :: super :: generics :: Skipped < 'i > , 0 >) , > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
+        :: pest_typed :: rule ! (r#DEC_LITERAL , "Corresponds to expression: `(DEC_DIGIT ~ (DEC_DIGIT | \"_\")*)`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#DEC_LITERAL , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: rules :: r#DEC_DIGIT :: < 'i , 0 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Rep :: < 'i , 0 , super :: super :: generics :: Choice2 :: < super :: super :: rules :: r#DEC_DIGIT :: < 'i , 0 > , super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_130 > , > > , super :: super :: generics :: Skipped < 'i > , 0 >) , > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
         impl<'i, const INHERITED: ::core::primitive::usize> r#DEC_LITERAL<'i, INHERITED> {}
-        :: pest_typed :: rule ! (r#BIN_LITERAL , "Corresponds to expression: `(\"0b\" ~ (BIN_DIGIT | \"_\")* ~ BIN_DIGIT ~ (BIN_DIGIT | \"_\")*)`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#BIN_LITERAL , super :: super :: generics :: Seq4 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_125 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Rep :: < 'i , 0 , super :: super :: generics :: Choice2 :: < super :: super :: rules :: r#BIN_DIGIT :: < 'i , 0 > , super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_126 > , > > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: rules :: r#BIN_DIGIT :: < 'i , 0 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Rep :: < 'i , 0 , super :: super :: generics :: Choice2 :: < super :: super :: rules :: r#BIN_DIGIT :: < 'i , 0 > , super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_127 > , > > , super :: super :: generics :: Skipped < 'i > , 0 >) , > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
+        :: pest_typed :: rule ! (r#BIN_LITERAL , "Corresponds to expression: `(\"0b\" ~ (BIN_DIGIT | \"_\")* ~ BIN_DIGIT ~ (BIN_DIGIT | \"_\")*)`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#BIN_LITERAL , super :: super :: generics :: Seq4 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_131 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Rep :: < 'i , 0 , super :: super :: generics :: Choice2 :: < super :: super :: rules :: r#BIN_DIGIT :: < 'i , 0 > , super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_132 > , > > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: rules :: r#BIN_DIGIT :: < 'i , 0 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Rep :: < 'i , 0 , super :: super :: generics :: Choice2 :: < super :: super :: rules :: r#BIN_DIGIT :: < 'i , 0 > , super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_133 > , > > , super :: super :: generics :: Skipped < 'i > , 0 >) , > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
         impl<'i, const INHERITED: ::core::primitive::usize> r#BIN_LITERAL<'i, INHERITED> {}
-        :: pest_typed :: rule ! (r#OCT_LITERAL , "Corresponds to expression: `(\"0o\" ~ (OCT_DIGIT | \"_\")* ~ OCT_DIGIT ~ (OCT_DIGIT | \"_\")*)`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#OCT_LITERAL , super :: super :: generics :: Seq4 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_128 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Rep :: < 'i , 0 , super :: super :: generics :: Choice2 :: < super :: super :: rules :: r#OCT_DIGIT :: < 'i , 0 > , super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_129 > , > > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: rules :: r#OCT_DIGIT :: < 'i , 0 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Rep :: < 'i , 0 , super :: super :: generics :: Choice2 :: < super :: super :: rules :: r#OCT_DIGIT :: < 'i , 0 > , super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_130 > , > > , super :: super :: generics :: Skipped < 'i > , 0 >) , > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
+        :: pest_typed :: rule ! (r#OCT_LITERAL , "Corresponds to expression: `(\"0o\" ~ (OCT_DIGIT | \"_\")* ~ OCT_DIGIT ~ (OCT_DIGIT | \"_\")*)`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#OCT_LITERAL , super :: super :: generics :: Seq4 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_134 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Rep :: < 'i , 0 , super :: super :: generics :: Choice2 :: < super :: super :: rules :: r#OCT_DIGIT :: < 'i , 0 > , super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_135 > , > > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: rules :: r#OCT_DIGIT :: < 'i , 0 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Rep :: < 'i , 0 , super :: super :: generics :: Choice2 :: < super :: super :: rules :: r#OCT_DIGIT :: < 'i , 0 > , super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_136 > , > > , super :: super :: generics :: Skipped < 'i > , 0 >) , > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
         impl<'i, const INHERITED: ::core::primitive::usize> r#OCT_LITERAL<'i, INHERITED> {}
-        :: pest_typed :: rule ! (r#HEX_LITERAL , "Corresponds to expression: `(\"0x\" ~ (HEX_DIGIT | \"_\")* ~ HEX_DIGIT ~ (HEX_DIGIT | \"_\")*)`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#HEX_LITERAL , super :: super :: generics :: Seq4 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_131 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Rep :: < 'i , 0 , super :: super :: generics :: Choice2 :: < super :: super :: rules :: r#HEX_DIGIT :: < 'i , 0 > , super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_132 > , > > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: rules :: r#HEX_DIGIT :: < 'i , 0 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Rep :: < 'i , 0 , super :: super :: generics :: Choice2 :: < super :: super :: rules :: r#HEX_DIGIT :: < 'i , 0 > , super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_133 > , > > , super :: super :: generics :: Skipped < 'i > , 0 >) , > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
+        :: pest_typed :: rule ! (r#HEX_LITERAL , "Corresponds to expression: `(\"0x\" ~ (HEX_DIGIT | \"_\")* ~ HEX_DIGIT ~ (HEX_DIGIT | \"_\")*)`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#HEX_LITERAL , super :: super :: generics :: Seq4 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_137 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Rep :: < 'i , 0 , super :: super :: generics :: Choice2 :: < super :: super :: rules :: r#HEX_DIGIT :: < 'i , 0 > , super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_138 > , > > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: rules :: r#HEX_DIGIT :: < 'i , 0 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Rep :: < 'i , 0 , super :: super :: generics :: Choice2 :: < super :: super :: rules :: r#HEX_DIGIT :: < 'i , 0 > , super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_139 > , > > , super :: super :: generics :: Skipped < 'i > , 0 >) , > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
         impl<'i, const INHERITED: ::core::primitive::usize> r#HEX_LITERAL<'i, INHERITED> {}
         :: pest_typed :: rule ! (r#IntegerSuffix , "Corresponds to expression: `(kw_u8 | kw_u16 | kw_u32 | kw_u64 | kw_usize | kw_i8 | kw_i16 | kw_i32 | kw_i64 | kw_isize)`. Normal rule." "" , super :: super :: Rule , super :: super :: Rule :: r#IntegerSuffix , super :: super :: generics :: Choice10 :: < super :: super :: rules :: r#kw_u8 :: < 'i , INHERITED > , super :: super :: rules :: r#kw_u16 :: < 'i , INHERITED > , super :: super :: rules :: r#kw_u32 :: < 'i , INHERITED > , super :: super :: rules :: r#kw_u64 :: < 'i , INHERITED > , super :: super :: rules :: r#kw_usize :: < 'i , INHERITED > , super :: super :: rules :: r#kw_i8 :: < 'i , INHERITED > , super :: super :: rules :: r#kw_i16 :: < 'i , INHERITED > , super :: super :: rules :: r#kw_i32 :: < 'i , INHERITED > , super :: super :: rules :: r#kw_i64 :: < 'i , INHERITED > , super :: super :: rules :: r#kw_isize :: < 'i , INHERITED > , > , super :: super :: generics :: Skipped :: < 'i > , INHERITED , Both , true);
         impl<'i, const INHERITED: ::core::primitive::usize> r#IntegerSuffix<'i, INHERITED> {
@@ -1983,7 +2133,7 @@ pub mod rules_impl {
                 }
             }
         }
-        :: pest_typed :: rule ! (r#String , "Corresponds to expression: `(\"\\\"\" ~ (!(\"\\\"\") ~ ANY)* ~ \"\\\"\")`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#String , super :: super :: generics :: Seq3 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_134 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Skip :: < super :: super :: constant_wrappers :: r#w_135 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_136 > , super :: super :: generics :: Skipped < 'i > , 0 >) , > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
+        :: pest_typed :: rule ! (r#String , "Corresponds to expression: `(\"\\\"\" ~ (!(\"\\\"\") ~ ANY)* ~ \"\\\"\")`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#String , super :: super :: generics :: Seq3 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_140 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Skip :: < super :: super :: constant_wrappers :: r#w_141 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_142 > , super :: super :: generics :: Skipped < 'i > , 0 >) , > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
         impl<'i, const INHERITED: ::core::primitive::usize> r#String<'i, INHERITED> {}
         :: pest_typed :: rule ! (r#Bool , "Corresponds to expression: `(kw_true | kw_false)`. Normal rule." "" , super :: super :: Rule , super :: super :: Rule :: r#Bool , super :: super :: generics :: Choice2 :: < super :: super :: rules :: r#kw_true :: < 'i , INHERITED > , super :: super :: rules :: r#kw_false :: < 'i , INHERITED > , > , super :: super :: generics :: Skipped :: < 'i > , INHERITED , Both , true);
         impl<'i, const INHERITED: ::core::primitive::usize> r#Bool<'i, INHERITED> {
@@ -2012,7 +2162,7 @@ pub mod rules_impl {
         }
         :: pest_typed :: rule ! (r#WordLeading , "Corresponds to expression: `(('a'..'z') | ('A'..'Z') | ('一'..'龥') | ('_'..'_'))`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#WordLeading , super :: super :: generics :: Choice4 :: < super :: super :: generics :: CharRange :: < 'a' , 'z' > , super :: super :: generics :: CharRange :: < 'A' , 'Z' > , super :: super :: generics :: CharRange :: < '一' , '龥' > , super :: super :: generics :: CharRange :: < '_' , '_' > , > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
         impl<'i, const INHERITED: ::core::primitive::usize> r#WordLeading<'i, INHERITED> {}
-        :: pest_typed :: rule ! (r#WordFollowing , "Corresponds to expression: `(WordLeading | \"_\" | \"-\" | ('0'..'9'))`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#WordFollowing , super :: super :: generics :: Choice4 :: < super :: super :: rules :: r#WordLeading :: < 'i , 0 > , super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_137 > , super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_138 > , super :: super :: generics :: CharRange :: < '0' , '9' > , > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
+        :: pest_typed :: rule ! (r#WordFollowing , "Corresponds to expression: `(WordLeading | \"_\" | \"-\" | ('0'..'9'))`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#WordFollowing , super :: super :: generics :: Choice4 :: < super :: super :: rules :: r#WordLeading :: < 'i , 0 > , super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_143 > , super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_144 > , super :: super :: generics :: CharRange :: < '0' , '9' > , > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
         impl<'i, const INHERITED: ::core::primitive::usize> r#WordFollowing<'i, INHERITED> {}
         :: pest_typed :: rule ! (r#Word , "Corresponds to expression: `(WordLeading ~ WordFollowing*)`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#Word , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: rules :: r#WordLeading :: < 'i , 0 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Rep :: < 'i , 0 , super :: super :: rules :: r#WordFollowing :: < 'i , 0 > > , super :: super :: generics :: Skipped < 'i > , 0 >) , > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
         impl<'i, const INHERITED: ::core::primitive::usize> r#Word<'i, INHERITED> {}
@@ -3938,7 +4088,7 @@ pub mod rules_impl {
                 }
             }
         }
-        :: pest_typed :: rule ! (r#TypeGroup , "Corresponds to expression: `(\"Group\" ~ Type)`. Normal rule." "" , super :: super :: Rule , super :: super :: Rule :: r#TypeGroup , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_139 > , super :: super :: generics :: Skipped < 'i > , INHERITED >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: rules :: r#Type :: < 'i , INHERITED > , super :: super :: generics :: Skipped < 'i > , INHERITED >) , > , super :: super :: generics :: Skipped :: < 'i > , INHERITED , Both , true);
+        :: pest_typed :: rule ! (r#TypeGroup , "Corresponds to expression: `(\"Group\" ~ Type)`. Normal rule." "" , super :: super :: Rule , super :: super :: Rule :: r#TypeGroup , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_145 > , super :: super :: generics :: Skipped < 'i > , INHERITED >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: rules :: r#Type :: < 'i , INHERITED > , super :: super :: generics :: Skipped < 'i > , INHERITED >) , > , super :: super :: generics :: Skipped :: < 'i > , INHERITED , Both , true);
         impl<'i, const INHERITED: ::core::primitive::usize> r#TypeGroup<'i, INHERITED> {
             #[doc = "A helper function to access [`Type`]."]
             #[allow(non_snake_case)]
@@ -9440,14 +9590,14 @@ pub mod rules_impl {
                 }
             }
         }
-        :: pest_typed :: rule ! (r#RPLPatternItem , "Corresponds to expression: `(Attr* ~ Identifier ~ MetaVariableDeclList? ~ Assign ~ RustItemsOrPatternOperation)`. Normal rule." "" , super :: super :: Rule , super :: super :: Rule :: r#RPLPatternItem , super :: super :: generics :: Seq5 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Rep :: < 'i , INHERITED , super :: super :: rules :: r#Attr :: < 'i , INHERITED > > , super :: super :: generics :: Skipped < 'i > , INHERITED >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: rules :: r#Identifier :: < 'i , INHERITED > , super :: super :: generics :: Skipped < 'i > , INHERITED >) , (:: pest_typed :: predefined_node :: Skipped < :: pest_typed :: re_exported :: Option :: < super :: super :: rules :: r#MetaVariableDeclList :: < 'i , INHERITED > > , super :: super :: generics :: Skipped < 'i > , INHERITED >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: rules :: r#Assign :: < 'i , INHERITED > , super :: super :: generics :: Skipped < 'i > , INHERITED >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: rules :: r#RustItemsOrPatternOperation :: < 'i , INHERITED > , super :: super :: generics :: Skipped < 'i > , INHERITED >) , > , super :: super :: generics :: Skipped :: < 'i > , INHERITED , Both , true);
+        :: pest_typed :: rule ! (r#RPLPatternItem , "Corresponds to expression: `(OuterDocComment* ~ Attr* ~ Identifier ~ MetaVariableDeclList? ~ Assign ~ RustItemsOrPatternOperation)`. Normal rule." "" , super :: super :: Rule , super :: super :: Rule :: r#RPLPatternItem , super :: super :: generics :: Seq6 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Rep :: < 'i , INHERITED , super :: super :: rules :: r#OuterDocComment :: < 'i , INHERITED > > , super :: super :: generics :: Skipped < 'i > , INHERITED >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Rep :: < 'i , INHERITED , super :: super :: rules :: r#Attr :: < 'i , INHERITED > > , super :: super :: generics :: Skipped < 'i > , INHERITED >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: rules :: r#Identifier :: < 'i , INHERITED > , super :: super :: generics :: Skipped < 'i > , INHERITED >) , (:: pest_typed :: predefined_node :: Skipped < :: pest_typed :: re_exported :: Option :: < super :: super :: rules :: r#MetaVariableDeclList :: < 'i , INHERITED > > , super :: super :: generics :: Skipped < 'i > , INHERITED >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: rules :: r#Assign :: < 'i , INHERITED > , super :: super :: generics :: Skipped < 'i > , INHERITED >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: rules :: r#RustItemsOrPatternOperation :: < 'i , INHERITED > , super :: super :: generics :: Skipped < 'i > , INHERITED >) , > , super :: super :: generics :: Skipped :: < 'i > , INHERITED , Both , true);
         impl<'i, const INHERITED: ::core::primitive::usize> r#RPLPatternItem<'i, INHERITED> {
             #[doc = "A helper function to access [`Assign`]."]
             #[allow(non_snake_case)]
             pub fn r#Assign<'s>(&'s self) -> &'s super::super::rules::r#Assign<'i, INHERITED> {
                 let res = &*self.content;
                 {
-                    let res = &res.content.3.matched;
+                    let res = &res.content.4.matched;
                     res
                 }
             }
@@ -9458,7 +9608,7 @@ pub mod rules_impl {
             ) -> ::pest_typed::re_exported::Vec<&'s super::super::rules::r#Attr<'i, INHERITED>> {
                 let res = &*self.content;
                 {
-                    let res = &res.content.0.matched;
+                    let res = &res.content.1.matched;
                     {
                         let res = res
                             .content
@@ -9477,7 +9627,7 @@ pub mod rules_impl {
             pub fn r#Identifier<'s>(&'s self) -> &'s super::super::rules::r#Identifier<'i, INHERITED> {
                 let res = &*self.content;
                 {
-                    let res = &res.content.1.matched;
+                    let res = &res.content.2.matched;
                     res
                 }
             }
@@ -9489,9 +9639,30 @@ pub mod rules_impl {
             {
                 let res = &*self.content;
                 {
-                    let res = &res.content.2.matched;
+                    let res = &res.content.3.matched;
                     {
                         let res = res.as_ref().map(|res| res);
+                        res
+                    }
+                }
+            }
+            #[doc = "A helper function to access [`OuterDocComment`]."]
+            #[allow(non_snake_case)]
+            pub fn r#OuterDocComment<'s>(
+                &'s self,
+            ) -> ::pest_typed::re_exported::Vec<&'s super::super::rules::r#OuterDocComment<'i, INHERITED>> {
+                let res = &*self.content;
+                {
+                    let res = &res.content.0.matched;
+                    {
+                        let res = res
+                            .content
+                            .iter()
+                            .map(|res| {
+                                let res = &res.matched;
+                                res
+                            })
+                            .collect::<::pest_typed::re_exported::Vec<_>>();
                         res
                     }
                 }
@@ -9503,7 +9674,7 @@ pub mod rules_impl {
             ) -> &'s super::super::rules::r#RustItemsOrPatternOperation<'i, INHERITED> {
                 let res = &*self.content;
                 {
-                    let res = &res.content.4.matched;
+                    let res = &res.content.5.matched;
                     res
                 }
             }
@@ -9646,7 +9817,7 @@ pub mod rules_impl {
                 }
             }
         }
-        :: pest_typed :: rule ! (r#diagMessageText , "Corresponds to expression: `(!(\"\\\"\" | LeftBrace) ~ ANY)+`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#diagMessageText , super :: super :: generics :: RepOnce :: < 'i , 0 , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Negative :: < super :: super :: generics :: Choice2 :: < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_140 > , super :: super :: rules :: r#LeftBrace :: < 'i , 0 > , > > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: rules :: r#ANY , super :: super :: generics :: Skipped < 'i > , 0 >) , > > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
+        :: pest_typed :: rule ! (r#diagMessageText , "Corresponds to expression: `(!(\"\\\"\" | LeftBrace) ~ ANY)+`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#diagMessageText , super :: super :: generics :: RepOnce :: < 'i , 0 , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Negative :: < super :: super :: generics :: Choice2 :: < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_146 > , super :: super :: rules :: r#LeftBrace :: < 'i , 0 > , > > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: rules :: r#ANY , super :: super :: generics :: Skipped < 'i > , 0 >) , > > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
         impl<'i, const INHERITED: ::core::primitive::usize> r#diagMessageText<'i, INHERITED> {}
         :: pest_typed :: rule ! (r#diagMessageInner , "Corresponds to expression: `(diagMessageArg | diagMessageText)*`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#diagMessageInner , super :: super :: generics :: Rep :: < 'i , 0 , super :: super :: generics :: Choice2 :: < super :: super :: rules :: r#diagMessageArg :: < 'i , 0 > , super :: super :: rules :: r#diagMessageText :: < 'i , 0 > , > > , super :: super :: generics :: Skipped :: < 'i > , true , Both , true);
         impl<'i, const INHERITED: ::core::primitive::usize> r#diagMessageInner<'i, INHERITED> {
@@ -9697,7 +9868,7 @@ pub mod rules_impl {
                 }
             }
         }
-        :: pest_typed :: rule ! (r#diagMessage , "Corresponds to expression: `(\"\\\"\" ~ diagMessageInner ~ \"\\\"\")`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#diagMessage , super :: super :: generics :: Seq3 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_141 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: rules :: r#diagMessageInner :: < 'i , 0 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_142 > , super :: super :: generics :: Skipped < 'i > , 0 >) , > , super :: super :: generics :: Skipped :: < 'i > , true , Both , true);
+        :: pest_typed :: rule ! (r#diagMessage , "Corresponds to expression: `(\"\\\"\" ~ diagMessageInner ~ \"\\\"\")`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#diagMessage , super :: super :: generics :: Seq3 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_147 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: rules :: r#diagMessageInner :: < 'i , 0 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_148 > , super :: super :: generics :: Skipped < 'i > , 0 >) , > , super :: super :: generics :: Skipped :: < 'i > , true , Both , true);
         impl<'i, const INHERITED: ::core::primitive::usize> r#diagMessage<'i, INHERITED> {
             #[doc = "A helper function to access [`diagMessageInner`]."]
             #[allow(non_snake_case)]
@@ -10079,14 +10250,14 @@ pub mod rules_impl {
                 }
             }
         }
-        :: pest_typed :: rule ! (r#diagBlockItem , "Corresponds to expression: `(Identifier ~ Assign ~ LeftBrace ~ diagItems ~ MetaVariableWithDiagMessageSeparatedByComma? ~ RightBrace)`. Normal rule." "" , super :: super :: Rule , super :: super :: Rule :: r#diagBlockItem , super :: super :: generics :: Seq6 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: rules :: r#Identifier :: < 'i , INHERITED > , super :: super :: generics :: Skipped < 'i > , INHERITED >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: rules :: r#Assign :: < 'i , INHERITED > , super :: super :: generics :: Skipped < 'i > , INHERITED >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: rules :: r#LeftBrace :: < 'i , INHERITED > , super :: super :: generics :: Skipped < 'i > , INHERITED >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: rules :: r#diagItems :: < 'i , INHERITED > , super :: super :: generics :: Skipped < 'i > , INHERITED >) , (:: pest_typed :: predefined_node :: Skipped < :: pest_typed :: re_exported :: Option :: < super :: super :: rules :: r#MetaVariableWithDiagMessageSeparatedByComma :: < 'i , INHERITED > > , super :: super :: generics :: Skipped < 'i > , INHERITED >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: rules :: r#RightBrace :: < 'i , INHERITED > , super :: super :: generics :: Skipped < 'i > , INHERITED >) , > , super :: super :: generics :: Skipped :: < 'i > , INHERITED , Both , true);
+        :: pest_typed :: rule ! (r#diagBlockItem , "Corresponds to expression: `(OuterDocComment* ~ Identifier ~ Assign ~ LeftBrace ~ diagItems ~ MetaVariableWithDiagMessageSeparatedByComma? ~ RightBrace)`. Normal rule." "" , super :: super :: Rule , super :: super :: Rule :: r#diagBlockItem , super :: super :: generics :: Seq7 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Rep :: < 'i , INHERITED , super :: super :: rules :: r#OuterDocComment :: < 'i , INHERITED > > , super :: super :: generics :: Skipped < 'i > , INHERITED >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: rules :: r#Identifier :: < 'i , INHERITED > , super :: super :: generics :: Skipped < 'i > , INHERITED >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: rules :: r#Assign :: < 'i , INHERITED > , super :: super :: generics :: Skipped < 'i > , INHERITED >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: rules :: r#LeftBrace :: < 'i , INHERITED > , super :: super :: generics :: Skipped < 'i > , INHERITED >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: rules :: r#diagItems :: < 'i , INHERITED > , super :: super :: generics :: Skipped < 'i > , INHERITED >) , (:: pest_typed :: predefined_node :: Skipped < :: pest_typed :: re_exported :: Option :: < super :: super :: rules :: r#MetaVariableWithDiagMessageSeparatedByComma :: < 'i , INHERITED > > , super :: super :: generics :: Skipped < 'i > , INHERITED >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: rules :: r#RightBrace :: < 'i , INHERITED > , super :: super :: generics :: Skipped < 'i > , INHERITED >) , > , super :: super :: generics :: Skipped :: < 'i > , INHERITED , Both , true);
         impl<'i, const INHERITED: ::core::primitive::usize> r#diagBlockItem<'i, INHERITED> {
             #[doc = "A helper function to access [`Assign`]."]
             #[allow(non_snake_case)]
             pub fn r#Assign<'s>(&'s self) -> &'s super::super::rules::r#Assign<'i, INHERITED> {
                 let res = &*self.content;
                 {
-                    let res = &res.content.1.matched;
+                    let res = &res.content.2.matched;
                     res
                 }
             }
@@ -10095,7 +10266,7 @@ pub mod rules_impl {
             pub fn r#Identifier<'s>(&'s self) -> &'s super::super::rules::r#Identifier<'i, INHERITED> {
                 let res = &*self.content;
                 {
-                    let res = &res.content.0.matched;
+                    let res = &res.content.1.matched;
                     res
                 }
             }
@@ -10104,7 +10275,7 @@ pub mod rules_impl {
             pub fn r#LeftBrace<'s>(&'s self) -> &'s super::super::rules::r#LeftBrace<'i, INHERITED> {
                 let res = &*self.content;
                 {
-                    let res = &res.content.2.matched;
+                    let res = &res.content.3.matched;
                     res
                 }
             }
@@ -10117,9 +10288,30 @@ pub mod rules_impl {
             > {
                 let res = &*self.content;
                 {
-                    let res = &res.content.4.matched;
+                    let res = &res.content.5.matched;
                     {
                         let res = res.as_ref().map(|res| res);
+                        res
+                    }
+                }
+            }
+            #[doc = "A helper function to access [`OuterDocComment`]."]
+            #[allow(non_snake_case)]
+            pub fn r#OuterDocComment<'s>(
+                &'s self,
+            ) -> ::pest_typed::re_exported::Vec<&'s super::super::rules::r#OuterDocComment<'i, INHERITED>> {
+                let res = &*self.content;
+                {
+                    let res = &res.content.0.matched;
+                    {
+                        let res = res
+                            .content
+                            .iter()
+                            .map(|res| {
+                                let res = &res.matched;
+                                res
+                            })
+                            .collect::<::pest_typed::re_exported::Vec<_>>();
                         res
                     }
                 }
@@ -10129,7 +10321,7 @@ pub mod rules_impl {
             pub fn r#RightBrace<'s>(&'s self) -> &'s super::super::rules::r#RightBrace<'i, INHERITED> {
                 let res = &*self.content;
                 {
-                    let res = &res.content.5.matched;
+                    let res = &res.content.6.matched;
                     res
                 }
             }
@@ -10138,7 +10330,7 @@ pub mod rules_impl {
             pub fn r#diagItems<'s>(&'s self) -> &'s super::super::rules::r#diagItems<'i, INHERITED> {
                 let res = &*self.content;
                 {
-                    let res = &res.content.3.matched;
+                    let res = &res.content.4.matched;
                     res
                 }
             }
@@ -10395,7 +10587,7 @@ pub mod rules_impl {
                 }
             }
         }
-        :: pest_typed :: rule ! (r#RPLPattern , "Corresponds to expression: `(RPLHeader ~ Block*)`. Normal rule." "" , super :: super :: Rule , super :: super :: Rule :: r#RPLPattern , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: rules :: r#RPLHeader :: < 'i , INHERITED > , super :: super :: generics :: Skipped < 'i > , INHERITED >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Rep :: < 'i , INHERITED , super :: super :: rules :: r#Block :: < 'i , INHERITED > > , super :: super :: generics :: Skipped < 'i > , INHERITED >) , > , super :: super :: generics :: Skipped :: < 'i > , INHERITED , Both , true);
+        :: pest_typed :: rule ! (r#RPLPattern , "Corresponds to expression: `(InnerDocComment* ~ RPLHeader ~ Block*)`. Normal rule." "" , super :: super :: Rule , super :: super :: Rule :: r#RPLPattern , super :: super :: generics :: Seq3 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Rep :: < 'i , INHERITED , super :: super :: rules :: r#InnerDocComment :: < 'i , INHERITED > > , super :: super :: generics :: Skipped < 'i > , INHERITED >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: rules :: r#RPLHeader :: < 'i , INHERITED > , super :: super :: generics :: Skipped < 'i > , INHERITED >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Rep :: < 'i , INHERITED , super :: super :: rules :: r#Block :: < 'i , INHERITED > > , super :: super :: generics :: Skipped < 'i > , INHERITED >) , > , super :: super :: generics :: Skipped :: < 'i > , INHERITED , Both , true);
         impl<'i, const INHERITED: ::core::primitive::usize> r#RPLPattern<'i, INHERITED> {
             #[doc = "A helper function to access [`Block`]."]
             #[allow(non_snake_case)]
@@ -10404,7 +10596,28 @@ pub mod rules_impl {
             ) -> ::pest_typed::re_exported::Vec<&'s super::super::rules::r#Block<'i, INHERITED>> {
                 let res = &*self.content;
                 {
-                    let res = &res.content.1.matched;
+                    let res = &res.content.2.matched;
+                    {
+                        let res = res
+                            .content
+                            .iter()
+                            .map(|res| {
+                                let res = &res.matched;
+                                res
+                            })
+                            .collect::<::pest_typed::re_exported::Vec<_>>();
+                        res
+                    }
+                }
+            }
+            #[doc = "A helper function to access [`InnerDocComment`]."]
+            #[allow(non_snake_case)]
+            pub fn r#InnerDocComment<'s>(
+                &'s self,
+            ) -> ::pest_typed::re_exported::Vec<&'s super::super::rules::r#InnerDocComment<'i, INHERITED>> {
+                let res = &*self.content;
+                {
+                    let res = &res.content.0.matched;
                     {
                         let res = res
                             .content
@@ -10423,7 +10636,7 @@ pub mod rules_impl {
             pub fn r#RPLHeader<'s>(&'s self) -> &'s super::super::rules::r#RPLHeader<'i, INHERITED> {
                 let res = &*self.content;
                 {
-                    let res = &res.content.0.matched;
+                    let res = &res.content.1.matched;
                     res
                 }
             }

--- a/crates/rpl_parser/tests/doc_comments.rs
+++ b/crates/rpl_parser/tests/doc_comments.rs
@@ -1,0 +1,149 @@
+//! Tests for the doc-comment productions added in the rpldoc work.
+//!
+//! Covers each of the three attachment points (file head, patt item,
+//! diag item), plus negative cases for stray placements.
+
+#![feature(rustc_private)]
+
+use rpl_parser::parse_main;
+use std::path::Path;
+
+fn assert_parses(label: &str, src: &str) {
+    let result = parse_main(src, Path::new("/synthetic/test.rpl"));
+    assert!(result.is_ok(), "{label}: expected Ok, got: {:?}", result.err());
+}
+
+fn assert_parse_error(label: &str, src: &str) {
+    let result = parse_main(src, Path::new("/synthetic/test.rpl"));
+    assert!(result.is_err(), "{label}: expected parse error, got Ok");
+}
+
+#[test]
+fn inner_doc_at_file_head_parses() {
+    let src = "\
+//! This pattern detects something.
+//! Continuation line.
+pattern Foo
+";
+    assert_parses("inner_doc_at_file_head", src);
+}
+
+#[test]
+fn outer_doc_on_patt_item_parses() {
+    let src = "\
+pattern Foo
+patt {
+    /// docs for the item
+    /// continuation
+    p_foo = fn _ (..) -> _ { _ = const 0_usize; }
+}
+";
+    assert_parses("outer_doc_on_patt_item", src);
+}
+
+#[test]
+fn outer_doc_on_diag_item_parses() {
+    let src = r#"
+pattern Foo
+diag {
+    /// description of the diagnostic
+    p_foo = {
+        primary(span) = "primary message",
+        level = "deny",
+        name = "foo_lint",
+    }
+}
+"#;
+    assert_parses("outer_doc_on_diag_item", src);
+}
+
+#[test]
+fn four_slash_is_not_doc_comment_parses() {
+    let src = "\
+//// ─── section divider ───
+pattern Foo
+";
+    // Should parse; the //// is a regular comment, NOT an InnerDocComment.
+    assert_parses("four_slash_is_not_doc_comment", src);
+}
+
+#[test]
+fn block_comment_at_file_head_parses() {
+    let src = "\
+/* block comment */
+pattern Foo
+";
+    assert_parses("block_comment_at_file_head", src);
+}
+
+#[test]
+fn doc_comment_in_pattern_body_is_parse_error() {
+    // `///` inside a function body has no attachment site in the grammar;
+    // the body grammar does not include OuterDocComment. This fails because
+    // of doc placement, not because of body syntax — verified with a valid
+    // surrounding body using `_ = const 0_usize;`.
+    let src = "\
+pattern Foo
+patt {
+    p_foo = fn _ (..) -> _ {
+        let $x: u8 = _;
+        /// stray doc inside body
+        let $y: u8 = copy $x;
+    }
+}
+";
+    assert_parse_error("doc_comment_in_pattern_body", src);
+}
+
+#[test]
+fn doc_after_attribute_is_parse_error() {
+    // Per grammar: OuterDocComment* comes BEFORE Attr*, so /// after #[..]
+    // does not have an attachment site. The body uses the valid form
+    // `_ = const 0_usize;` so the error is solely due to doc placement.
+    let src = r#"
+pattern Foo
+patt {
+    #[diag = "p_foo"]
+    /// surprise — wrong order
+    p_foo = fn _ (..) -> _ { _ = const 0_usize; }
+}
+"#;
+    assert_parse_error("doc_after_attribute", src);
+}
+
+#[test]
+fn inner_doc_inside_block_is_parse_error() {
+    // //! only legal at file head, not inside a patt/diag block.
+    // The body uses the valid form `_ = const 0_usize;` so the error is
+    // solely due to the misplaced //! token.
+    let src = "\
+pattern Foo
+patt {
+    //! not a valid placement
+    p_foo = fn _ (..) -> _ { _ = const 0_usize; }
+}
+";
+    assert_parse_error("inner_doc_inside_block", src);
+}
+
+#[test]
+fn doc_separated_by_blank_line_still_attaches() {
+    // The pest grammar does NOT enforce rustdoc-style "blank line breaks
+    // the run" semantics. `OuterDocComment*` greedily matches consecutive
+    // /// lines because WHITESPACE (which skips blank lines) is consumed
+    // between them.
+    //
+    // The extraction layer in rpl_doc treats all attached /// lines as
+    // one doc block. Authors who want to convey "two separate ideas"
+    // should put the second below the next item, not before the same one.
+    let src = "\
+pattern Foo
+patt {
+    /// first run
+
+    /// second run
+    p_foo = fn _ (..) -> _ { _ = const 0_usize; }
+}
+";
+    assert_parses("doc_separated_by_blank_line_still_attaches", src);
+}

--- a/crates/rpl_parser/tests/doc_comments.rs
+++ b/crates/rpl_parser/tests/doc_comments.rs
@@ -5,8 +5,9 @@
 
 #![feature(rustc_private)]
 
-use rpl_parser::parse_main;
 use std::path::Path;
+
+use rpl_parser::parse_main;
 
 fn assert_parses(label: &str, src: &str) {
     let result = parse_main(src, Path::new("/synthetic/test.rpl"));

--- a/docs/development/examples/Sample-Documented.md
+++ b/docs/development/examples/Sample-Documented.md
@@ -1,0 +1,64 @@
+# Sample-Documented
+
+Reference pattern demonstrating rpldoc conventions.
+
+This file is documented end-to-end so authors can copy-paste the
+structure. It does not detect any real bug — `p_sample` is a no-op
+pattern that matches a trivial assignment.
+
+See `docs/development/rpldoc-authoring.md` for the authoring guide.
+
+## Patterns
+
+### `p_sample`
+
+Matches a function whose body contains a trivial usize assignment.
+
+**What to document here:** explain what code shape this pattern detects,
+under what conditions it fires, and any caveats (false positives, edge
+cases) authors should know. The first line should be a short summary
+that stands alone; subsequent paragraphs (separated by an empty `///`
+line) can expand on it.
+
+The `#[diag = "p_sample"]` attribute below cross-references the
+diagnostic group of the same name — the generated docs render this as
+a clickable link to the `## Diagnostics` section.
+
+**Diagnostic:** [`p_sample`](#diagnostic-p_sample)
+
+**Signature:** `fn _ (..) -> _`
+
+<details><summary>Pattern body</summary>
+
+```rpl
+_ = const 0_usize;
+```
+</details>
+
+## Diagnostics
+
+<a id="diagnostic-p_sample"></a>
+### Diagnostic: `p_sample`
+
+Diagnostic emitted whenever `p_sample` matches.
+
+The `///` block in front of a diagnostic group lets you document
+the lint name and the rationale separately from the matching shape.
+
+- **Primary:** `trivial usize assignment found`
+- **Help:** `this is a demo lint; remove the assignment`
+- **Level:** `warn`
+- **Lint name:** `sample_lint`
+
+## Examples
+
+### Example: `triggering.rs`
+
+Minimal example that would trigger `sample_lint`.
+
+```rust
+fn main() {
+    let _: usize = 0;
+}
+```
+

--- a/docs/development/examples/Sample-Documented.rpl
+++ b/docs/development/examples/Sample-Documented.rpl
@@ -1,0 +1,40 @@
+//! Reference pattern demonstrating rpldoc conventions.
+//!
+//! This file is documented end-to-end so authors can copy-paste the
+//! structure. It does not detect any real bug — `p_sample` is a no-op
+//! pattern that matches a trivial assignment.
+//!
+//! See `docs/development/rpldoc-authoring.md` for the authoring guide.
+
+pattern Sample-Documented
+
+patt {
+    /// Matches a function whose body contains a trivial usize assignment.
+    ///
+    /// **What to document here:** explain what code shape this pattern detects,
+    /// under what conditions it fires, and any caveats (false positives, edge
+    /// cases) authors should know. The first line should be a short summary
+    /// that stands alone; subsequent paragraphs (separated by an empty `///`
+    /// line) can expand on it.
+    ///
+    /// The `#[diag = "p_sample"]` attribute below cross-references the
+    /// diagnostic group of the same name — the generated docs render this as
+    /// a clickable link to the `## Diagnostics` section.
+    #[diag = "p_sample"]
+    p_sample = fn _ (..) -> _ {
+        _ = const 0_usize;
+    }
+}
+
+diag {
+    /// Diagnostic emitted whenever `p_sample` matches.
+    ///
+    /// The `///` block in front of a diagnostic group lets you document
+    /// the lint name and the rationale separately from the matching shape.
+    p_sample = {
+        primary(span) = "trivial usize assignment found",
+        help(span) = "this is a demo lint; remove the assignment",
+        level = "warn",
+        name = "sample_lint",
+    }
+}

--- a/docs/development/examples/Sample-Documented/triggering.rs
+++ b/docs/development/examples/Sample-Documented/triggering.rs
@@ -1,0 +1,5 @@
+//! Minimal example that would trigger `sample_lint`.
+
+fn main() {
+    let _: usize = 0;
+}

--- a/docs/development/rpldoc-authoring.md
+++ b/docs/development/rpldoc-authoring.md
@@ -11,10 +11,29 @@ nicely with `cargo rpl doc`. For the full design spec, see
 | `//!` | At the very top of the `.rpl` file, before `pattern <Name>`. | The file as a whole. |
 | `///` | Immediately before a `patt`/`util` item, or before a `diag` item. | That single item. |
 
-A run of consecutive `///` (or `//!`) lines is treated as one block. A
-blank line breaks the run — exactly like rustdoc. Doc-comment content
-is rendered as raw Markdown; use inline code, lists, and `####` or
-deeper headings freely.
+A run of consecutive `///` (or `//!`) lines is treated as one paragraph.
+You can use either an empty `///` line OR a true blank line (no `///`
+prefix) to start a new paragraph. Both forms render as Markdown paragraph
+breaks. Doc-comment content is rendered as raw Markdown; use inline code,
+lists, and `####` or deeper headings freely.
+
+Example — two paragraphs above the same item:
+
+```rpl
+/// First paragraph: what this pattern detects.
+///
+/// Second paragraph: caveats or false positives.
+p_foo = fn _ (..) -> _ { … }
+```
+
+Equivalent (blank line instead of empty `///`):
+
+```rpl
+/// First paragraph: what this pattern detects.
+
+/// Second paragraph: caveats or false positives.
+p_foo = fn _ (..) -> _ { … }
+```
 
 ## Strict placement
 

--- a/docs/development/rpldoc-authoring.md
+++ b/docs/development/rpldoc-authoring.md
@@ -36,10 +36,16 @@ document.
 See [`examples/Sample-Documented.rpl`](examples/Sample-Documented.rpl)
 for a complete file. The companion folder
 [`examples/Sample-Documented/`](examples/Sample-Documented/) holds the
-`.rs` examples it points to.
+`.rs` examples it points to, and
+[`examples/Sample-Documented.md`](examples/Sample-Documented.md) is the
+output rpldoc produces from this source — read it side-by-side with the
+`.rpl` to see what each `//!` and `///` block becomes.
 
-Run `cargo rpl doc docs/development/examples/Sample-Documented.rpl`
-to see the generated Markdown.
+To regenerate it locally, run:
+
+```sh
+cargo rpl doc docs/development/examples/Sample-Documented.rpl
+```
 
 ## Generated layout
 

--- a/docs/development/rpldoc-authoring.md
+++ b/docs/development/rpldoc-authoring.md
@@ -1,0 +1,104 @@
+# Authoring rpldoc Documentation
+
+This guide explains how to document `.rpl` pattern files so they render
+nicely with `cargo rpl doc`. For the full design spec, see
+[`docs/superpowers/specs/2026-05-26-rpldoc-design.md`](../superpowers/specs/2026-05-26-rpldoc-design.md).
+
+## The two doc-comment forms
+
+| Form | Where | What it documents |
+|------|-------|-------------------|
+| `//!` | At the very top of the `.rpl` file, before `pattern <Name>`. | The file as a whole. |
+| `///` | Immediately before a `patt`/`util` item, or before a `diag` item. | That single item. |
+
+A run of consecutive `///` (or `//!`) lines is treated as one block. A
+blank line breaks the run — exactly like rustdoc. Doc-comment content
+is rendered as raw Markdown; use inline code, lists, and `####` or
+deeper headings freely.
+
+## Strict placement
+
+Doc comments are only legal at the three attachment points above. A
+`///` placed anywhere else — inside a pattern body, between an
+attribute and the item name, before a `use` path — is a parse error.
+This is by design: the same way Rust rejects `#[doc = "..."]` in an
+illegal position.
+
+If you see an error like
+```
+expected one of OuterDocComment, Attr, Identifier
+```
+move the doc comment to immediately before the item you meant to
+document.
+
+## Worked example
+
+See [`examples/Sample-Documented.rpl`](examples/Sample-Documented.rpl)
+for a complete file. The companion folder
+[`examples/Sample-Documented/`](examples/Sample-Documented/) holds the
+`.rs` examples it points to.
+
+Run `cargo rpl doc docs/development/examples/Sample-Documented.rpl`
+to see the generated Markdown.
+
+## Generated layout
+
+For a file `<dir>/<stem>.rpl`, rpldoc emits `<dir>/<stem>.md` with
+sections in this order, omitting any empty section:
+
+1. `# <PatternHeaderName>` — the title.
+2. File-level prose, rendered verbatim from the `//!` block.
+3. `## Patterns` — one `### `<name>`` subsection per `patt` item.
+4. `## Utilities` — one subsection per `util` item.
+5. `## Diagnostics` — one anchored subsection per diagnostic group.
+6. `## Examples` — one fenced code block per `.rs` file in the
+   sibling `<stem>/` folder.
+
+Inside each pattern subsection:
+- The `///` prose, if any.
+- A `**Diagnostic:**` link if the item carries `#[diag = "..."]`.
+- A `**Signature:**` line showing the item head.
+- A `<details>`-collapsed code block with the pattern body.
+
+## The examples folder
+
+For `<dir>/<stem>.rpl`, rpldoc looks for a sibling folder
+`<dir>/<stem>/`. If it exists, every `.rs` file in it is embedded as
+an `## Example: <filename.rs>` subsection in lexicographic order.
+
+You can prepend a `//!` block to an example `.rs` file; rpldoc strips
+it from the embedded source and renders it as prose above the code
+block. This is the recommended way to caption examples.
+
+Non-`.rs` files in the folder are ignored. Subdirectories are not
+recursed.
+
+## Running the tool
+
+```sh
+# Single file
+cargo rpl doc path/to/Foo.rpl
+
+# Recursive over a directory
+cargo rpl doc docs/patterns-pest/cve/
+
+# Mirror outputs into a separate tree
+cargo rpl doc docs/patterns-pest/ --output /tmp/rpl-docs/
+
+# Quiet mode (suppress per-file status lines)
+cargo rpl doc docs/patterns-pest/ --quiet
+```
+
+## Best practices
+
+- **Lead with one short summary sentence.** Authors and tools alike
+  benefit from a first line that stands alone.
+- **Separate "what it detects" from "how it detects."** Use a
+  paragraph break (an empty `///` line) between intent and mechanism.
+- **Link to the CVE/issue.** Use inline Markdown links — they render
+  in any Markdown viewer.
+- **Reference the diagnostic by name from the pattern's `///`.** The
+  `[`name`](#diagnostic-name)` link works out of the box; don't
+  hand-craft slugs.
+- **Use code spans (`backticks`) liberally.** Type names, function
+  paths, MIR fragments — anything that would be code in prose.

--- a/src/main.rs
+++ b/src/main.rs
@@ -247,7 +247,17 @@ fn run_doc(args: Vec<String>) -> Result<(), i32> {
                 output_root = Some(std::path::PathBuf::from(v));
             },
             s if s.starts_with("--output=") => {
-                output_root = Some(std::path::PathBuf::from(&s["--output=".len()..]));
+                let value = &s["--output=".len()..];
+                if value.is_empty() {
+                    eprintln!("error: --output= requires a value");
+                    return Err(2);
+                }
+                output_root = Some(std::path::PathBuf::from(value));
+            },
+            s if s.starts_with("--") => {
+                eprintln!("error: unrecognized flag: {s}");
+                eprintln!("usage: cargo rpl doc <PATH> [--output <DIR>] [--quiet]");
+                return Err(2);
             },
             _ => {
                 if path.is_some() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 // warn on lints, that are included in `rust-lang/rust`s bootstrap
 #![warn(rust_2018_idioms, unused_lifetimes)]
+#![feature(rustc_private)]
 
 use std::env;
 use std::path::PathBuf;
@@ -37,6 +38,15 @@ pub fn main() {
             show_help();
         }
         return;
+    }
+
+    // rpldoc subcommand: `cargo rpl doc <PATH> [--output <DIR>] [--quiet]`
+    if env::args().nth(2).as_deref() == Some("doc") {
+        let doc_args: Vec<String> = env::args().skip(3).collect();
+        match run_doc(doc_args) {
+            Ok(()) => return,
+            Err(code) => process::exit(code),
+        }
     }
 
     if let Err(code) = process(env::args().skip(2)) {
@@ -218,6 +228,49 @@ fn apply_inline_mir(cmd: &mut Command, inline_mir: bool) {
             cmd.env("RUSTFLAGS", flag);
         },
     }
+}
+
+fn run_doc(args: Vec<String>) -> Result<(), i32> {
+    let mut path: Option<std::path::PathBuf> = None;
+    let mut output_root: Option<std::path::PathBuf> = None;
+    let mut quiet = false;
+
+    let mut it = args.into_iter();
+    while let Some(arg) = it.next() {
+        match arg.as_str() {
+            "--quiet" => quiet = true,
+            "--output" => {
+                let v = it.next().ok_or_else(|| {
+                    eprintln!("error: --output requires a value");
+                    2
+                })?;
+                output_root = Some(std::path::PathBuf::from(v));
+            }
+            s if s.starts_with("--output=") => {
+                output_root = Some(std::path::PathBuf::from(&s["--output=".len()..]));
+            }
+            _ => {
+                if path.is_some() {
+                    eprintln!("error: only one PATH argument supported");
+                    return Err(2);
+                }
+                path = Some(std::path::PathBuf::from(arg));
+            }
+        }
+    }
+
+    let path = path.ok_or_else(|| {
+        eprintln!("usage: cargo rpl doc <PATH> [--output <DIR>] [--quiet]");
+        2
+    })?;
+
+    let opts = rpl_doc::GenerateOpts { output_root, quiet };
+    rpl_doc::run_cli(&path, opts).map_err(|errors| {
+        for e in errors {
+            eprintln!("error: {e}");
+        }
+        1
+    })
 }
 
 #[must_use]

--- a/src/main.rs
+++ b/src/main.rs
@@ -245,17 +245,17 @@ fn run_doc(args: Vec<String>) -> Result<(), i32> {
                     2
                 })?;
                 output_root = Some(std::path::PathBuf::from(v));
-            }
+            },
             s if s.starts_with("--output=") => {
                 output_root = Some(std::path::PathBuf::from(&s["--output=".len()..]));
-            }
+            },
             _ => {
                 if path.is_some() {
                     eprintln!("error: only one PATH argument supported");
                     return Err(2);
                 }
                 path = Some(std::path::PathBuf::from(arg));
-            }
+            },
         }
     }
 


### PR DESCRIPTION
## Summary

Adds **rpldoc** — a documentation feature for \`.rpl\` pattern files, analogous to rustdoc:

- \`//!\` doc comments at the top of a file → file-level prose
- \`///\` doc comments before any \`patt\`/\`util\` item or \`diag\` group → item-level docs
- \`cargo rpl doc <path>\` generates one Markdown file per \`.rpl\`, with sibling-folder \`.rs\` files embedded as worked examples

The feature is purely additive: existing pattern files are unchanged, the linter pipeline is unaffected, and a backward-compat sweep test confirms all 155 existing patterns under \`docs/patterns-pest/\` still parse identically.

## What's included

**New \`rpl_doc\` crate** (\`crates/rpl_doc/\`):
- \`model.rs\` — plain-data types (\`DocFile\`, \`DocItem\`, \`DocDiag\`, \`DocExample\`)
- \`extract.rs\` — walks the typed pest AST to build the doc model
- \`examples.rs\` — discovers \`<dir>/<stem>/*.rs\` sibling examples and promotes any leading \`//!\` block from the example file to prose above the embedded code
- \`render.rs\` — emits Markdown with fence-length escalation and inline-code escaping (so backticks like \`\` \`Vec::from_raw_parts\` \`\` inside diagnostic messages render correctly)
- \`error.rs\` — \`RpldocError\` (Io, Parse, MissingPatternHeader, NotUtf8, OutputWrite)

**Pest grammar change** (\`crates/rpl_parser/src/grammar/RPL.pest\`):
- New productions: \`DocComment\`, \`OuterDocComment\`, \`InnerDocComment\`, \`DocCommentText\`, \`LineCommentNonDoc\`, \`BlockComment\`
- \`COMMENT\` now skips only non-doc line and block comments
- \`RPLPattern\`, \`RPLPatternItem\`, \`diagBlockItem\` accept leading doc comments
- 8 mechanical cascade fixes in \`rpl_meta\` and \`rpl_context\` for positional-tuple shifts caused by the new attachment-point fields (no behavior change)

**New \`doc\` subcommand on \`cargo-rpl\`** (\`src/main.rs\`):
\`\`\`
cargo rpl doc <PATH> [--output <DIR>] [--quiet]
\`\`\`
Walks directories recursively, mirrors output tree when \`--output\` is given, never modifies the source tree.

**Tests** (all green, ~322 passing across the workspace):
- 47 unit tests in \`rpl_doc\`
- 9 parser tests in \`rpl_parser/tests/doc_comments.rs\`
- 6 integration fixtures (round-trip \`.rpl\` → \`.expected.md\`)
- 4 end-to-end CLI tests driving the actual binary
- 1 corpus-sweep backward-compat gate

**Documentation**:
- \`docs/development/rpldoc-authoring.md\` — author-facing guide explaining \`//!\` vs \`///\`, the strict-placement rule, generated layout, examples folder convention, CLI invocations, and best practices
- \`docs/development/examples/Sample-Documented.rpl\` + \`docs/development/examples/Sample-Documented/triggering.rs\` — a hand-crafted, fully-documented reference pattern authors can read and copy
- README pointer in "Quick Start" section
- CONTRIBUTING soft note (not enforced)

## Non-goals (v1)

- Backfilling docs on existing pattern files — capability only; population is gradual, author-by-author follow-up.
- Cross-pattern hyperlinks, HTML/static-site output, index/SUMMARY.md generation.
- Lint-style enforcement of documentation.
- Block-style \`/** ... */\` doc comments.

## Showcase

Running \`cargo rpl doc docs/patterns-pest/cve/CVE-2018-21000.rpl\` against the existing pattern produces a complete Markdown file with:

- \`# CVE-2018-21000\` title
- Four \`### \`p_*\`\` subsections, each with signature line + collapsible \`<details>\` body
- \`## Diagnostics\` with a stable anchor and properly-escaped backticks inside the bullets (so \`\` \`Vec::from_raw_parts\` \`\` doesn't break the inline code span)
- No \`## Examples\` section (no sibling folder exists yet — authors can add one whenever)

## Test Plan

- [x] \`cargo test --workspace\` — zero failures across all crates
- [x] Corpus-sweep gate confirms backward compatibility with the existing pattern corpus
- [x] End-to-end CLI tests cover single-file, directory, \`--output\`, and parse-error modes
- [x] CVE-2018-21000 (a real pattern with multi-line meta-vars and backticks in its diag) renders cleanly
- [x] No \`.rpl\` files under \`docs/patterns-pest/\` were modified

— Generated by Claude Opus 4.7 (1M context) on behalf of @jellllly420

🤖 Generated with [Claude Code](https://claude.com/claude-code)